### PR TITLE
Move to 0.2.0 and pin versions for $big company

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
+# Disabling as going to pin for non OSS use
+#  - package-ecosystem: "cargo"
+#    directory: "/"
+#    schedule:
+#      interval: "weekly"
+#      day: "monday"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monitord"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Cooper Ry Lees <me@cooperlees.com>"]
 license = "GPL-2.0-or-later"
 readme = "README.md"
@@ -13,19 +13,19 @@ categories = ["network-programming", "os::linux-apis"]
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "3.2.22", features = ["derive"] }
-clap-verbosity-flag = "1.0.1"
+clap = { version = "3.2.17", features = ["derive"] }
+clap-verbosity-flag = "1.0"
 configparser = "3.0.2"
-dbus = "0.9.6"
-env_logger = "0.9"
-itertools = "0.10.5"
+dbus = "0.9.3"
+env_logger = "0.7"
+itertools = "0.10.3"
 log = "0.4"
-serde = { version = "1.0.145", features = ["derive"] }
-serde_json = "1.0.85"
-serde_repr = "0.1.9"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0"
+serde_repr = "0.1"
 struct-field-names-as-array = "0.1.3"
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.21"
+strum_macros = "0.21"
 
 [dev-dependencies]
 oxidized-json-checker = "0.3.2"


### PR DESCRIPTION
- Move version to release to crates.io
- Pinning deps to make importing to $big company easier
- Stop dependbot updating deps ... Will move with $big company each release

Test: Ensure tests still pass and run locally on Linux box