### PR TITLE
Allow config driven DBUS Address to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ to match systemd unit files.
 # Pure ini - no yes/no for bools
 
 [monitord]
+# Set a custom dbus address to connect to
+# OPTIONAL: If not set, we default to the Unix socket below
+dbus_address = unix:path=/run/dbus/system_bus_socket
+# Get debug output
 debug = false
 # Run as a daemon or 1 time
 daemon = false

--- a/monitord.conf
+++ b/monitord.conf
@@ -2,6 +2,7 @@
 # Pure ini - no yes/no for bools
 
 [monitord]
+dbus_address = unix:path=/run/dbus/system_bus_socket
 debug = true
 daemon = false
 daemon_stats_refresh_secs = 60

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,8 @@ pub fn stat_collector(config: Ini) -> Result<(), String> {
         // Run units collector if enabled
         if read_config_bool(&config, String::from("units"), String::from("enabled")) {
             ran_collector_count += 1;
-            match units::parse_unit_state() {
+            let dbus_address = config.get("monitord", "dbus_address");
+            match units::parse_unit_state(dbus_address) {
                 Ok(units_stats) => monitord_stats.units = units_stats,
                 Err(err) => error!("units stats failed: {}", err),
             }

--- a/src/networkd.rs
+++ b/src/networkd.rs
@@ -13,7 +13,7 @@ systemd enums copied from https://github.com/systemd/systemd/blob/main/src/libsy
 */
 
 #[allow(non_camel_case_types)]
-#[derive(Serialize_repr, Deserialize_repr, Debug, Eq, PartialEq, EnumString)]
+#[derive(Serialize_repr, Deserialize_repr, Clone, Copy, Debug, Eq, PartialEq, EnumString)]
 #[repr(u8)]
 pub enum AddressState {
     unknown = 0,
@@ -23,7 +23,7 @@ pub enum AddressState {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Serialize_repr, Deserialize_repr, Debug, Eq, PartialEq, EnumString)]
+#[derive(Serialize_repr, Deserialize_repr, Clone, Copy, Debug, Eq, PartialEq, EnumString)]
 #[repr(u8)]
 pub enum AdminState {
     unknown = 0,
@@ -36,7 +36,7 @@ pub enum AdminState {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Serialize_repr, Deserialize_repr, Debug, Eq, PartialEq, EnumString)]
+#[derive(Serialize_repr, Deserialize_repr, Clone, Copy, Debug, Eq, PartialEq, EnumString)]
 #[repr(u8)]
 pub enum BoolState {
     unknown = u8::MAX,
@@ -57,7 +57,7 @@ pub enum BoolState {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Serialize_repr, Deserialize_repr, Debug, Eq, PartialEq, EnumString)]
+#[derive(Serialize_repr, Deserialize_repr, Clone, Copy, Debug, Eq, PartialEq, EnumString)]
 #[repr(u8)]
 pub enum CarrierState {
     unknown = 0,
@@ -72,7 +72,7 @@ pub enum CarrierState {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Serialize_repr, Deserialize_repr, Debug, Eq, PartialEq, EnumString)]
+#[derive(Serialize_repr, Deserialize_repr, Clone, Copy, Debug, Eq, PartialEq, EnumString)]
 #[repr(u8)]
 pub enum OnlineState {
     unknown = 0,
@@ -82,7 +82,7 @@ pub enum OnlineState {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Serialize_repr, Deserialize_repr, Debug, Eq, PartialEq, EnumString)]
+#[derive(Serialize_repr, Deserialize_repr, Clone, Copy, Debug, Eq, PartialEq, EnumString)]
 #[repr(u8)]
 pub enum OperState {
     unknown = 0,

--- a/src/units.rs
+++ b/src/units.rs
@@ -5,6 +5,8 @@ use dbus::blocking::Connection;
 use log::debug;
 use struct_field_names_as_array::FieldNamesAsArray;
 
+const DEFAULT_DBUS_ADDRESS: &str = "unix:path=/run/dbus/system_bus_socket";
+
 #[derive(
     serde::Serialize, serde::Deserialize, Debug, Default, Eq, FieldNamesAsArray, PartialEq,
 )]
@@ -81,7 +83,13 @@ fn parse_unit(
     }
 }
 
-pub fn parse_unit_state() -> Result<SystemdUnitStats, Box<dyn std::error::Error>> {
+pub fn parse_unit_state(
+    potential_dbus_address: Option<String>,
+) -> Result<SystemdUnitStats, Box<dyn std::error::Error>> {
+    std::env::set_var(
+        "DBUS_SYSTEM_BUS_ADDRESS",
+        potential_dbus_address.unwrap_or_else(|| String::from(DEFAULT_DBUS_ADDRESS)),
+    );
     let mut stats = SystemdUnitStats::default();
     let c = Connection::new_system()?;
     let p = c.with_proxy(


### PR DESCRIPTION
- Add monitord dbus_address config param
- Allow it to be option and fallback to a default

Test: `cargo run -- -v -c monitord.conf`

Fixes #14