### PR TITLE
Move default services to collect stats on to a match statement

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -220,7 +220,7 @@ fn flatten_units(
             }
             _ => {
                 if !fields_to_ignore.contains(field_name) {
-                   debug!("Got a unhandled stat '{}'", field_name);
+                    debug!("Got a unhandled stat '{}'", field_name);
                 }
             }
         };

--- a/src/json.rs
+++ b/src/json.rs
@@ -154,6 +154,9 @@ fn flatten_units(
     units_stats: &units::SystemdUnitStats,
     key_prefix: &String,
 ) -> HashMap<String, JsonFlatValue> {
+    // fields of the SystemdUnitStats struct we know to ignore so don't log below
+    let fields_to_ignore = Vec::from(["service_stats"]);
+
     let mut flat_stats: HashMap<String, JsonFlatValue> = HashMap::new();
     let base_metric_name = gen_base_metric_key(key_prefix, &String::from("units"));
 
@@ -216,7 +219,9 @@ fn flatten_units(
                 flat_stats.insert(key, JsonFlatValue::U64(units_stats.total_units));
             }
             _ => {
-                debug!("Got a unhandled stat '{}'", field_name);
+                if !fields_to_ignore.contains(field_name) {
+                   debug!("Got a unhandled stat '{}'", field_name);
+                }
             }
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::thread;
@@ -110,14 +109,12 @@ pub fn stat_collector(config: Ini) -> Result<(), String> {
             }
         }
 
-        // Run units collector if enabled
+        // Run service collectors if there are services listed in config
         let config_map = config.get_map().expect("Unable to get a config map");
-        let default_services_hashmap = HashMap::new();
-        let services_to_get_stats: Vec<&String> = config_map
-            .get("services")
-            .unwrap_or(&default_services_hashmap)
-            .keys()
-            .collect();
+        let services_to_get_stats: Vec<&String> = match config_map.get("services") {
+            Some(services_hash) => services_hash.keys().collect(),
+            None => Vec::from([]),
+        };
         if read_config_bool(&config, String::from("units"), String::from("enabled")) {
             ran_collector_count += 1;
             match units::parse_unit_state(&dbus_address, services_to_get_stats) {


### PR DESCRIPTION
- Had issues unwrapping_or to a HashMap compiling in some environments
- We only need an empty vector, so lets use a match statement to do so if the config has no `[services]` section
- Add in fix to not log service_stats as a missed field in flatten_units

Test:

- Remove `[services]` from monitord.conf and test running
  - `cargo run -c monitord.conf -vv`