### PR TITLE
Move to tracing for logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monitord"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Cooper Ry Lees <me@cooperlees.com>"]
 license = "GPL-2.0-or-later"
 readme = "README.md"
@@ -14,18 +14,19 @@ categories = ["network-programming", "os::linux-apis"]
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.2", features = ["derive"] }
-clap-verbosity-flag = "2.0"
 configparser = "3.0.2"
 dbus = "0.9.3"
-env_logger = "0.10"
 itertools = "0.10.3"
-log = "0.4"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
 struct-field-names-as-array = "0.1.3"
 strum = "0.21"
 strum_macros = "0.21"
+tracing = "0.1"
+tracing-core = "0.1"
+tracing-glog = "0.2"
+tracing-subscriber = "0.3"
 
 [dev-dependencies]
 oxidized-json-checker = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -28,30 +28,29 @@ Install via cargo or use as a dependency in your `Cargo.toml`.
 
 ```console
 crl-linux:monitord cooper$ monitord --help
-monitord 0.2.0
+monitord 0.5.0
 Cooper Ry Lees <me@cooperlees.com>
 monitord: Know how happy your systemd is! 😊
 
-USAGE:
-    monitord [OPTIONS]
+Usage: monitord [OPTIONS]
 
-OPTIONS:
-    -c, --config <CONFIG>
-            Location of your monitord config
+Options:
+  -c, --config <CONFIG>
+          Location of your monitord config
 
-            [default: /etc/monitord.conf]
+          [default: /etc/monitord.conf]
 
-    -h, --help
-            Print help information
+  -l, --log-level <LOG_LEVEL>
+          Adjust the console log-level
 
-    -q, --quiet
-            Less output per occurrence
+          [default: Info]
+          [possible values: error, warn, info, debug, trace]
 
-    -v, --verbose
-            More output per occurrence
+  -h, --help
+          Print help (see a summary with '-h')
 
-    -V, --version
-            Print version information
+  -V, --version
+          Print version
 ```
 
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use log::debug;
+use tracing::debug;
 
 use crate::networkd;
 use crate::units;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,11 @@ use std::time::Instant;
 
 use anyhow::Result;
 use configparser::ini::Ini;
-use log::error;
-use log::info;
+use tracing::error;
+use tracing::info;
 
 pub mod json;
+pub mod logging;
 mod network_dbus;
 pub mod networkd;
 mod systemd_dbus;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,41 @@
+use clap::ValueEnum;
+use tracing_glog::Glog;
+use tracing_glog::GlogFields;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Registry;
+
+// This enum can be used to add `log-level` option to CLI binaries.
+#[derive(ValueEnum, Clone, Debug, Copy)]
+pub enum LogLevels {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<LogLevels> for LevelFilter {
+    fn from(public_level: LogLevels) -> Self {
+        match public_level {
+            LogLevels::Error => LevelFilter::ERROR,
+            LogLevels::Warn => LevelFilter::WARN,
+            LogLevels::Info => LevelFilter::INFO,
+            LogLevels::Debug => LevelFilter::DEBUG,
+            LogLevels::Trace => LevelFilter::TRACE,
+        }
+    }
+}
+
+pub fn setup_logging(log_filter_level: LevelFilter) {
+    let fmt = fmt::Layer::default()
+        .with_writer(std::io::stderr)
+        .event_format(Glog::default().with_timer(tracing_glog::LocalTime::default()))
+        .fmt_fields(GlogFields)
+        .with_filter(log_filter_level);
+
+    let subscriber = Registry::default().with(fmt);
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Unable to set global tracing subscriber");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,9 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use clap_verbosity_flag::InfoLevel;
 use configparser::ini::Ini;
-use log::debug;
-use log::info;
+use tracing::debug;
+use tracing::info;
 
 const LONG_ABOUT: &str = "monitord: Know how happy your systemd is! 😊";
 
@@ -16,15 +15,15 @@ struct Cli {
     /// Location of your monitord config
     #[clap(short, long, value_parser, default_value = "/etc/monitord.conf")]
     config: PathBuf,
-    #[clap(flatten)]
-    verbose: clap_verbosity_flag::Verbosity<InfoLevel>,
+
+    /// Adjust the console log-level
+    #[arg(long, short, value_enum, ignore_case = true, default_value = "Info")]
+    log_level: monitord::logging::LogLevels,
 }
 
 fn main() -> Result<(), String> {
     let args = Cli::parse();
-    env_logger::Builder::new()
-        .filter_level(args.verbose.log_level_filter())
-        .init();
+    monitord::logging::setup_logging(args.log_level.into());
 
     info!("{}", LONG_ABOUT);
     debug!("CLI Args: {:?}", args);

--- a/src/networkd.rs
+++ b/src/networkd.rs
@@ -6,9 +6,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use dbus::blocking::Connection;
-use log::error;
 use serde_repr::*;
 use strum_macros::EnumString;
+use tracing::error;
 
 /*
 systemd enums copied from https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-network/network-util.h

--- a/src/units.rs
+++ b/src/units.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use dbus::blocking::Connection;
-use log::debug;
-use log::error;
 use struct_field_names_as_array::FieldNamesAsArray;
+use tracing::debug;
+use tracing::error;
 
 #[derive(
     serde::Serialize, serde::Deserialize, Debug, Default, Eq, FieldNamesAsArray, PartialEq,


### PR DESCRIPTION
- tracing is the hostness for logging these days, lets use it
  - Move to widely adopted glog format with local system time
- Move to version 0.5.0 + due to changing logging libraries

Test:
- See all CI pass
- Run and see logging still