### PR TITLE
chore: bump to tracing-glog 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ strum = "0.21"
 strum_macros = "0.21"
 tracing = "0.1"
 tracing-core = "0.1"
-tracing-glog = "0.2"
+tracing-glog = "0.3"
 tracing-subscriber = "0.3"
 
 [dev-dependencies]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -32,7 +32,7 @@ pub fn setup_logging(log_filter_level: LevelFilter) {
     let fmt = fmt::Layer::default()
         .with_writer(std::io::stderr)
         .event_format(Glog::default().with_timer(tracing_glog::LocalTime::default()))
-        .fmt_fields(GlogFields)
+        .fmt_fields(GlogFields::default())
         .with_filter(log_filter_level);
 
     let subscriber = Registry::default().with(fmt);


### PR DESCRIPTION
Handles https://github.com/davidbarsky/tracing-glog/releases/tag/v0.3.0.