### PR TITLE
Fix handling of units with no running processes

### DIFF
--- a/src/units.rs
+++ b/src/units.rs
@@ -57,6 +57,16 @@ pub struct ServiceStats {
 pub const SERVICE_FIELD_NAMES: &[&str] = ServiceStats::FIELD_NAMES_AS_ARRAY;
 pub const UNIT_FIELD_NAMES: &[&str] = SystemdUnitStats::FIELD_NAMES_AS_ARRAY;
 
+// Handle there being no processes for stopped units etc.
+// TODO: Go through the Vec of tuples and sum up all the processes for services with multiple PIDs
+fn parse_processes(processes: Vec<(String, u32, String)>) -> u32 {
+    debug!("Found the following processes: {:?}", processes);
+    if processes.len() < 1 {
+        return 0;
+    }
+    processes[0].1
+}
+
 fn parse_service(c: &Connection, name: &str, path: &str) -> Result<ServiceStats, dbus::Error> {
     debug!("Parsing service {} stats", name);
     let p = c.with_proxy("org.freedesktop.systemd1", path, Duration::new(2, 0));
@@ -72,7 +82,7 @@ fn parse_service(c: &Connection, name: &str, path: &str) -> Result<ServiceStats,
         memory_current: p.memory_current()?,
         memory_available: p.memory_available()?,
         nrestarts: p.nrestarts()?,
-        processes: p.get_processes()?[0].1,
+        processes: parse_processes(p.get_processes()?),
         restart_usec: p.restart_usec()?,
         state_change_timestamp: p.state_change_timestamp()?,
         status_errno: p.status_errno()?,
@@ -149,7 +159,7 @@ pub fn parse_unit_state(
     for unit in units {
         parse_unit(&mut stats, unit.clone());
         if services_to_get_stats.contains(&&unit.0) {
-            debug!("Collecting service stats for {}", &unit.0);
+            debug!("Collecting service stats for {:?}", &unit);
             match parse_service(&c, &unit.0, &unit.6) {
                 Ok(service_stats) => {
                     stats.service_stats.insert(unit.0.clone(), service_stats);
@@ -168,6 +178,18 @@ pub fn parse_unit_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_processes() {
+        let active_unit_processes = vec![(
+            String::from("/system.slice/sshd.service"),
+            6969,
+            String::from("\"sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups\""),
+        )];
+        assert_eq!(6969, parse_processes(active_unit_processes));
+        let non_active_unit_processes_total = vec![];
+        assert_eq!(0, parse_processes(non_active_unit_processes_total));
+    }
 
     #[test]
     fn test_unit_parse() {


### PR DESCRIPTION
- Create small function to handle if we have no processes rather than assuming we always have a running process

Test:
- Add unittest
- Run with a non running service in the monitord.conf

Addresses part of #47