### PR TITLE
Add per unit state stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,20 @@ link_state_dir = /run/systemd/netif/links
 # .service is important as that's what DBus returns from `list_units`
 [services]
 foo.service
-sshd.service
 
 # Grab unit status counts via dbus
 [units]
 enabled = true
+state_stats = true
+
+# Filter what services you want collect state stats for
+# If both lists are configured blocklist is preferred
+# If neither exist all units state will generate counters
+[units.state_stats.allowed]
+foo.service
+
+[units.state_stats.disallowed]
+bar.service
 ```
 
 ## Output Formats
@@ -170,6 +179,8 @@ Is semi pretty too + custom. All unittested ...
   "services.chronyd.service.tasks_current": 1,
   "services.chronyd.service.timeout_clean_usec": 18446744073709551615,
   "services.chronyd.service.watchdog_usec": 0,
+  "monitord.unit_states.chronyd.service.active_state": 1,
+  "monitord.unit_states.chronyd.service.loaded_state": 1,
   "units.active_units": 403,
   "units.automount_units": 1,
   "units.device_units": 150,

--- a/monitord.conf
+++ b/monitord.conf
@@ -18,3 +18,8 @@ sshd.service
 
 [units]
 enabled = true
+state_stats = true
+
+[units.state_stats.allowlist]
+chronyd.service
+sshd.service

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,21 +104,17 @@ pub fn stat_collector(config: Ini) -> Result<(), String> {
                 &dbus_address,
             ) {
                 Ok(networkd_stats) => monitord_stats.networkd = networkd_stats,
-                Err(err) => error!("networkd stats failed: {}", err),
+                Err(err) => error!("networkd stats failed: {:?}", err),
             }
         }
 
         // Run service collectors if there are services listed in config
         let config_map = config.get_map().expect("Unable to get a config map");
-        let services_to_get_stats: Vec<&String> = match config_map.get("services") {
-            Some(services_hash) => services_hash.keys().collect(),
-            None => Vec::from([]),
-        };
         if read_config_bool(&config, String::from("units"), String::from("enabled")) {
             ran_collector_count += 1;
-            match units::parse_unit_state(&dbus_address, services_to_get_stats) {
+            match units::parse_unit_state(&dbus_address, config_map) {
                 Ok(units_stats) => monitord_stats.units = units_stats,
-                Err(err) => error!("units stats failed: {}", err),
+                Err(err) => error!("units stats failed: {:?}", err),
             }
         }
 


### PR DESCRIPTION
- Add a new HashMap of UnitStates structs to hold per unit states
  - We only do ActiveState and LoadedState
- Add config to
  - Enable state collection
  - Allow list of units to collect state for
  - Block list of units to colelct state for

Tests:
- Add unittest for parse_state
- Add unit state to JSON unittests
- Run on my fedora box to see the state stats for chonry + sshd
  - `cargo run -- -l debug -c monitord.conf`
```
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/monitord -l debug -c monitord.conf`
I0914 15:39:38.590418 823276 src/main.rs:28] monitord: Know how happy your systemd is! 😊
D0914 15:39:38.590504 823276 src/main.rs:29] CLI Args: Cli { config: "monitord.conf", log_level: Debug }
D0914 15:39:38.590542 823276 src/main.rs:30] Loading "monitord.conf" config
I0914 15:39:38.590691 823276 src/lib.rs:89] Starting stat collection run
...
D0914 15:39:38.615899 823276 src/units.rs:186] Skipping state stats for chefctl.timer due to not being in allowlist
...
  "monitord.unit_states.chronyd.service.active_state": 1,
  "monitord.unit_states.chronyd.service.loaded_state": 1,
  "monitord.unit_states.sshd.service.active_state": 1,
  "monitord.unit_states.sshd.service.loaded_state": 1,
...
```