### PR TITLE
Add system-state metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Is semi pretty too + custom. All unittested ...
   "services.chronyd.service.tasks_current": 1,
   "services.chronyd.service.timeout_clean_usec": 18446744073709551615,
   "services.chronyd.service.watchdog_usec": 0,
+  "system-state": 3,
   "unit_states.chronyd.service.active_state": 1,
   "unit_states.chronyd.service.loaded_state": 1,
   "units.active_units": 403,

--- a/monitord.conf
+++ b/monitord.conf
@@ -19,6 +19,9 @@ enabled = true
 chronyd.service
 sshd.service
 
+[system-state]
+enabled = true
+
 [units]
 enabled = true
 state_stats = true

--- a/src/json.rs
+++ b/src/json.rs
@@ -307,6 +307,10 @@ pub fn flatten_hashmap(
     let mut flat_stats: HashMap<String, JsonFlatValue> = HashMap::new();
     flat_stats.extend(flatten_networkd(&stats_struct.networkd, key_prefix));
     flat_stats.extend(flatten_pid1(&stats_struct.pid1, key_prefix));
+    flat_stats.insert(
+        gen_base_metric_key(key_prefix, &String::from("system-state")),
+        JsonFlatValue::U64(stats_struct.system_state as u64),
+    );
     flat_stats.extend(flatten_services(
         &stats_struct.units.service_stats,
         key_prefix,
@@ -381,6 +385,7 @@ mod tests {
   "services.unittest.service.tasks_current": 0,
   "services.unittest.service.timeout_clean_usec": 0,
   "services.unittest.service.watchdog_usec": 0,
+  "system-state": 3,
   "unit_states.unittest.service.active_state": 1,
   "unit_states.unittest.service.load_state": 1,
   "units.active_units": 0,
@@ -433,6 +438,7 @@ mod tests {
   "monitord.services.unittest.service.tasks_current": 0,
   "monitord.services.unittest.service.timeout_clean_usec": 0,
   "monitord.services.unittest.service.watchdog_usec": 0,
+  "monitord.system-state": 3,
   "monitord.unit_states.unittest.service.active_state": 1,
   "monitord.unit_states.unittest.service.load_state": 1,
   "monitord.units.active_units": 0,
@@ -478,6 +484,7 @@ mod tests {
                 fd_count: 69,
                 tasks: 1,
             }),
+            system_state: crate::system::SystemdSystemState::running,
             units: crate::units::SystemdUnitStats::default(),
         };
         let service_unit_name = String::from("unittest.service");
@@ -502,7 +509,7 @@ mod tests {
     #[test]
     fn test_flatten_hashmap() {
         let json_flat_map = flatten_hashmap(&return_monitord_stats(), &String::from(""));
-        assert_eq!(49, json_flat_map.len());
+        assert_eq!(50, json_flat_map.len());
     }
 
     #[test]

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use dbus::blocking::Connection;
+use int_enum::IntEnum;
+use serde_repr::Deserialize_repr;
+use serde_repr::Serialize_repr;
+use strum_macros::EnumString;
+use tracing::error;
+
+#[allow(non_camel_case_types)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    EnumString,
+    IntEnum,
+    strum_macros::ToString,
+)]
+#[repr(u8)]
+pub enum SystemdSystemState {
+    #[default]
+    unknown = 0,
+    initializing = 1,
+    starting = 2,
+    running = 3,
+    degraded = 4,
+    maintenance = 5,
+    stopping = 6,
+    offline = 7,
+}
+
+pub fn get_system_state(dbus_address: &str) -> Result<SystemdSystemState, dbus::Error> {
+    std::env::set_var("DBUS_SYSTEM_BUS_ADDRESS", dbus_address);
+    let c = Connection::new_system()?;
+    let p = c.with_proxy(
+        "org.freedesktop.systemd1",
+        "/org/freedesktop/systemd1",
+        Duration::new(5, 0),
+    );
+    use crate::dbus::systemd::OrgFreedesktopSystemd1Manager;
+    let state = match p.system_state() {
+        Ok(system_state) => match system_state.as_str() {
+            "initializing" => crate::system::SystemdSystemState::initializing,
+            "starting" => crate::system::SystemdSystemState::starting,
+            "running" => crate::system::SystemdSystemState::running,
+            "degraded" => crate::system::SystemdSystemState::degraded,
+            "maintenance" => crate::system::SystemdSystemState::maintenance,
+            "stopping" => crate::system::SystemdSystemState::stopping,
+            "offline" => crate::system::SystemdSystemState::offline,
+            _ => crate::system::SystemdSystemState::unknown,
+        },
+        Err(err) => {
+            error!("Failed to get system-state: {:?}", err);
+            crate::system::SystemdSystemState::unknown
+        }
+    };
+    Ok(state)
+}


### PR DESCRIPTION
If set in config, pull the system state
- Know if we've started up cleanly or not ...

Tests:
- Add to JSON tests