### PR TITLE
Remove all uses of strum_macros::ToString macro

### DIFF
--- a/src/networkd.rs
+++ b/src/networkd.rs
@@ -28,7 +28,7 @@ use tracing::error;
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum AddressState {
@@ -50,7 +50,7 @@ pub enum AddressState {
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum AdminState {
@@ -75,7 +75,7 @@ pub enum AdminState {
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum BoolState {
@@ -108,7 +108,7 @@ pub enum BoolState {
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum CarrierState {
@@ -135,7 +135,7 @@ pub enum CarrierState {
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum OnlineState {
@@ -157,7 +157,7 @@ pub enum OnlineState {
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum OperState {

--- a/src/system.rs
+++ b/src/system.rs
@@ -24,7 +24,7 @@ use tracing::error;
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum SystemdSystemState {
@@ -65,4 +65,14 @@ pub fn get_system_state(dbus_address: &str) -> Result<SystemdSystemState, dbus::
         }
     };
     Ok(state)
+}
+
+mod tests {
+    #[test]
+    fn test_display_struct() {
+        assert_eq!(
+            format!("{}", crate::system::SystemdSystemState::running),
+            String::from("running"),
+        )
+    }
 }

--- a/src/units.rs
+++ b/src/units.rs
@@ -96,7 +96,7 @@ pub struct UnitStates {
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum SystemdUnitActiveState {
@@ -123,7 +123,7 @@ pub enum SystemdUnitActiveState {
     PartialEq,
     EnumString,
     IntEnum,
-    strum_macros::ToString,
+    strum_macros::Display,
 )]
 #[repr(u8)]
 pub enum SystemdUnitLoadState {


### PR DESCRIPTION
- We now get Display support using strum::Display macro