### PR TITLE
Make unit unhealthy check only care about LoadState::loaded

### DIFF
--- a/src/units.rs
+++ b/src/units.rs
@@ -75,9 +75,8 @@ pub struct ServiceStats {
 pub struct UnitStates {
     pub active_state: SystemdUnitActiveState,
     pub load_state: SystemdUnitLoadState,
-    // Unhealthy is only calculated for SystemdUnitLoadState::loaded units based on state
-    // and SystemdUnitLoadState::[error||not_found]
-    // "unhealthy" here means ~active for loaded units - thus systemd should have the process running ...
+    // Unhealthy is only calculated for SystemdUnitLoadState::loaded units based on !SystemdActiveState::active
+    // and !SystemdUnitLoadState::masked
     pub unhealthy: bool,
 }
 


### PR DESCRIPTION
- If a unit is not loaded, let's not mark it as unhealthy
  - Add function to do this simple logic + so we can unit test it to ensure it behaves how we want
- Let's assume the admin if the system(s) running monitord know what they are doing and have marked it / non loaded / deleted it etc. on purpose
  - People can use dedicated !loaded checks if they want to find units in specific states
- "Unhealthy" means !active only when loaded ...

Test:
Add unit test showing function doing what we expect