### PR TITLE
Refactor stat_collector to run all collections in async parallel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,7 @@ pub async fn stat_collector(config: config::Config) -> anyhow::Result<()> {
     let locked_monitord_stats: Arc<RwLock<MonitordStats>> =
         Arc::new(RwLock::new(MonitordStats::default()));
     std::env::set_var("DBUS_SYSTEM_BUS_ADDRESS", &config.monitord.dbus_address);
-    let sdc = match zbus::Connection::system().await {
-        Ok(sdc) => sdc,
-        Err(e) => return Err(e.into()),
-    };
+    let sdc = zbus::Connection::system().await?;
     let mut join_set = tokio::task::JoinSet::new();
     loop {
         let collect_start_time = Instant::now();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,13 @@
 //! # monitord Crate
 //!
 //! `monitord` is a library to gather statistics about systemd.
-//! Some APIs are a little ugly due to being a configparser INI based configuration
-//! driven CLL at heart.
 
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
-use anyhow::Result;
+use tokio::sync::RwLock;
 use tracing::error;
 use tracing::info;
 
@@ -56,94 +55,99 @@ pub fn print_stats(
 }
 
 /// Main statictic collection function running what's required by configuration
-pub async fn stat_collector(config: config::Config) -> Result<(), String> {
+pub async fn stat_collector(config: config::Config) -> anyhow::Result<()> {
     let mut collect_interval_ms: u128 = 0;
     if config.monitord.daemon {
         collect_interval_ms = (config.monitord.daemon_stats_refresh_secs * 1000).into();
     }
 
-    let mut monitord_stats = MonitordStats::default();
+    let locked_monitord_stats: Arc<RwLock<MonitordStats>> =
+        Arc::new(RwLock::new(MonitordStats::default()));
     std::env::set_var("DBUS_SYSTEM_BUS_ADDRESS", &config.monitord.dbus_address);
     let sdc = match zbus::Connection::system().await {
         Ok(sdc) => sdc,
-        Err(e) => {
-            return Err(format!(
-                "Unable to connect to system dbus via zbus: {:?}",
-                e
-            ))
-        }
+        Err(e) => return Err(e.into()),
     };
+    let mut join_set = tokio::task::JoinSet::new();
     loop {
         let collect_start_time = Instant::now();
         let mut ran_collector_count: u8 = 0;
 
         info!("Starting stat collection run");
 
-        // TODO: Refactor to run all async methods in parallel
         // Collect pid1 procfs stats
         if config.pid1.enabled {
-            let pid1_stats = match tokio::task::spawn_blocking(crate::pid1::get_pid1_stats).await {
-                Ok(p1s) => p1s,
-                Err(err) => {
-                    return Err(format!(
-                        "Unable to spawn blocking around PID1 stats: {:?}",
-                        err
-                    ))
-                }
-            };
-            monitord_stats.pid1 = match pid1_stats {
-                Ok(s) => Some(s),
-                Err(err) => {
-                    error!("Unable to set pid1 stats: {:?}", err);
-                    None
-                }
-            }
+            ran_collector_count += 1;
+            join_set.spawn(crate::pid1::update_pid1_stats(
+                locked_monitord_stats.clone(),
+            ));
         }
 
         // Run networkd collector if enabled
         if config.networkd.enabled {
             ran_collector_count += 1;
-            match networkd::parse_interface_state_files(&config.networkd.link_state_dir, None, &sdc)
-                .await
-            {
-                Ok(networkd_stats) => monitord_stats.networkd = networkd_stats,
-                Err(err) => error!("networkd stats failed: {:?}", err),
-            }
+            join_set.spawn(crate::networkd::update_networkd_stats(
+                config.networkd.link_state_dir.clone(),
+                None,
+                sdc.clone(),
+                locked_monitord_stats.clone(),
+            ));
         }
 
         // Run system running (SystemState) state collector
         if config.system_state.enabled {
             ran_collector_count += 1;
-            monitord_stats.system_state = crate::system::get_system_state(&sdc)
-                .await
-                .map_err(|e| format!("Error getting system state: {:?}", e))?;
+            join_set.spawn(crate::system::update_system_stats(
+                sdc.clone(),
+                locked_monitord_stats.clone(),
+            ));
         }
         // Not incrementing the ran_collector_count on purpose as this is always on by default
-        monitord_stats.version = crate::system::get_version(&sdc)
-            .await
-            .map_err(|e| format!("Error getting systemd versions: {:?}", e))?;
+        join_set.spawn(crate::system::update_version(
+            sdc.clone(),
+            locked_monitord_stats.clone(),
+        ));
 
         // Run service collectors if there are services listed in config
         if config.units.enabled {
             ran_collector_count += 1;
-            match units::parse_unit_state(&config, &sdc).await {
-                Ok(units_stats) => monitord_stats.units = units_stats,
-                Err(err) => error!("units stats failed: {:?}", err),
-            }
+            join_set.spawn(crate::units::update_unit_stats(
+                config.clone(),
+                sdc.clone(),
+                locked_monitord_stats.clone(),
+            ));
         }
 
         if ran_collector_count < 1 {
-            error!("No collectors ran. Exiting");
+            error!("No collectors scheduled to run. Exiting");
             std::process::exit(1);
+        }
+
+        // Check all collection for errors
+        while let Some(res) = join_set.join_next().await {
+            match res {
+                Ok(r) => match r {
+                    Ok(_) => (),
+                    Err(e) => {
+                        error!("Collection specific failure: {:?}", e);
+                    }
+                },
+                Err(e) => {
+                    error!("Join error: {:?}", e);
+                }
+            }
         }
 
         let elapsed_runtime_ms = collect_start_time.elapsed().as_millis();
         info!("stat collection run took {}ms", elapsed_runtime_ms);
-        print_stats(
-            &config.monitord.key_prefix,
-            &config.monitord.output_format,
-            &monitord_stats,
-        );
+        {
+            let monitord_stats = locked_monitord_stats.read().await;
+            print_stats(
+                &config.monitord.key_prefix,
+                &config.monitord.output_format,
+                &monitord_stats,
+            );
+        }
         if !config.monitord.daemon {
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
 use clap::Parser;
 use configparser::ini::Ini;
 use tracing::debug;
@@ -22,7 +21,7 @@ struct Cli {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), String> {
+async fn main() -> anyhow::Result<()> {
     let args = Cli::parse();
     monitord::logging::setup_logging(args.log_level.into());
 
@@ -30,7 +29,9 @@ async fn main() -> Result<(), String> {
     debug!("CLI Args: {:?}", args);
     debug!("Loading {:?} config", args.config.as_os_str());
     let mut config = Ini::new();
-    let _config_map = config.load(args.config)?;
+    let _config_map = config
+        .load(args.config)
+        .map_err(|e| anyhow::anyhow!("Config error: {:?}", e))?;
 
     monitord::stat_collector(config.into()).await
 }


### PR DESCRIPTION
- Now that we have an async dbus client, lets make this function
- Add an update_*_stats API in each module + pass a RWLocked stats struct to update
- Join and check for any errors + log etc.

Test Plan:
- Run and see same stats
- Didn't notice much runtime win here ... down from 12-13ms to 11-12ms
  - 10ms if I disable networkd
  - Still got some networkd I/O to make async ... will do that in a follow up dedicated PR
```
cooper@cooper-fedora-MJ0J8MTZ:~/repos/monitord$ ls -lh target/release/monitord
-rwxr-xr-x. 2 cooper cooper 3.5M Oct  1 09:04 target/release/monitord

cooper@cooper-fedora-MJ0J8MTZ:~/repos/monitord$ time ./target/release/monitord -c monitord.conf > /dev/null
I1001 09:05:16.258015 3289269 src/main.rs:28] monitord: Know how happy your systemd is! 😊
I1001 09:05:16.258750 3289269 src/lib.rs:76] Starting stat collection run
E1001 09:05:16.259904 3289269 src/networkd.rs:308] Unable to get interface links via DBUS - is networkd running?: MethodError(
    OwnedErrorName(
        "org.freedesktop.DBus.Error.NameHasNoOwner",
    ),
    Some(
        "Could not activate remote peer 'org.freedesktop.network1': activation request failed: unknown unit",
    ),
    Msg {
        type: Error,
        sender: UniqueName(
            "org.freedesktop.DBus",
        ),
        reply-serial: 2,
        body: Signature(
            "s",
        ),
        fds: [],
    },
)
I1001 09:05:16.269851 3289269 src/lib.rs:142] stat collection run took 11ms

real	0m0.020s
user	0m0.005s
sys	0m0.026s
```
- No networkd running on Fedora