### PR TITLE
Move back to hard pinned zbus versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ tracing = "0.1"
 tracing-core = "0.1"
 tracing-glog = "0.4"
 tracing-subscriber = "0.3"
-zbus = { version = ">=4, <6", features = ["p2p", "tokio"] }
+zbus = { version = "4.4.0", features = ["p2p", "tokio"] }
+zvariant = "4.2.0"
+zvariant_derive = "4.2.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"


### PR DESCRIPTION
- For non Cargo build we need explicit versions for the derived macro expansion
- Big Company that uses this needs that explictly

So we only support dbus 4 still, except in cargo worlds.