### PR TITLE
fix: restore clap help feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming", "os::linux-apis"]
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.5", features = ["derive", "std"], default-features = false }
+clap = { version = "4.5", features = ["derive", "std", "help"], default-features = false }
 configparser = { version = "3.0.3", features = ["indexmap"] }
 indexmap = "2.2"
 int-enum = "1.1"


### PR DESCRIPTION
In a previous commit, default features were disable to optimize release binary size, but this broke the `--help` functionality mentioned in the README of monitord.

This is the output from a default install from crates.io
```
   Installed package `monitord v0.12.0` (executable `monitord`)                                │
❯ monitord --help                                                                              │  -V, --version
error: unexpected argument found
```

With this PR we just add the help feature. This still keeps the binary small
```
-rwxr-xr-x 2 vasuper vasuper 2.3M Jan 10 21:58 monitord
```