### PR TITLE
Add time_in_state_usec to unit states

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -207,6 +207,9 @@ fn flatten_unit_states(
                         flat_stats.insert(key, 1.into());
                     }
                 },
+                "time_in_state_usecs" => {
+                    flat_stats.insert(key, unit_state_stats.time_in_state_usecs.into());
+                }
                 _ => {
                     debug!("Got a unhandled unit state: '{}'", field_name);
                 }
@@ -425,9 +428,11 @@ mod tests {
   "system-state": 3,
   "unit_states.nvme\\x2dWDC_CL_SN730_SDBQNTY\\x2d512G\\x2d2020_37222H80070511\\x2dpart3.device.active_state": 1,
   "unit_states.nvme\\x2dWDC_CL_SN730_SDBQNTY\\x2d512G\\x2d2020_37222H80070511\\x2dpart3.device.load_state": 1,
+  "unit_states.nvme\\x2dWDC_CL_SN730_SDBQNTY\\x2d512G\\x2d2020_37222H80070511\\x2dpart3.device.time_in_state_usecs": 69,
   "unit_states.nvme\\x2dWDC_CL_SN730_SDBQNTY\\x2d512G\\x2d2020_37222H80070511\\x2dpart3.device.unhealthy": 0,
   "unit_states.unittest.service.active_state": 1,
   "unit_states.unittest.service.load_state": 1,
+  "unit_states.unittest.service.time_in_state_usecs": 69,
   "unit_states.unittest.service.unhealthy": 0,
   "units.active_units": 0,
   "units.automount_units": 0,
@@ -496,6 +501,7 @@ mod tests {
                 active_state: units::SystemdUnitActiveState::active,
                 load_state: units::SystemdUnitLoadState::loaded,
                 unhealthy: false,
+                time_in_state_usecs: 69,
             },
         );
         // Ensure we escape keys correctly
@@ -507,6 +513,7 @@ mod tests {
                 active_state: units::SystemdUnitActiveState::active,
                 load_state: units::SystemdUnitLoadState::loaded,
                 unhealthy: false,
+                time_in_state_usecs: 69,
             },
         );
         stats
@@ -518,7 +525,7 @@ mod tests {
             &return_monitord_stats(),
             &String::from("JSON serialize failed"),
         );
-        assert_eq!(77, json_flat_map.len());
+        assert_eq!(79, json_flat_map.len());
     }
 
     #[test]


### PR DESCRIPTION
- Here we add a calculation of microseconds since the state of this unit last changed
- This could be handy to know to see if multiple units all started failing around the same time or if a service(s) are flapping states

Test:
- Keep unittests passing
- Run locally and see calculations seem sane
  - Had to install openssh-server to see it on my docker container
```
[root@b89a51f4c266 repo]# cargo run -- -c monitord.conf
...
I0315 02:57:15.529738  5905 src/lib.rs:182] stat collection run took 18ms
...
  "monitord.unit_states.sshd.service.active_state": 1,
  "monitord.unit_states.sshd.service.load_state": 1,
  "monitord.unit_states.sshd.service.time_in_state_usecs": 1302552480,
...
```
- Restarted sshd to see the number much lower
```
  "monitord.unit_states.sshd.service.time_in_state_usecs": 9315586,
```