### PR TITLE
Add Timer stats

### DIFF
--- a/monitord.conf
+++ b/monitord.conf
@@ -23,6 +23,9 @@ sshd.service
 [system-state]
 enabled = true
 
+[timers]
+enabled = true
+
 [units]
 enabled = true
 state_stats = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,6 +82,16 @@ impl Default for SystemStateConfig {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimersConfig {
+    pub enabled: bool,
+}
+impl Default for TimersConfig {
+    fn default() -> Self {
+        TimersConfig { enabled: true }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnitsConfig {
     pub enabled: bool,
     pub state_stats: bool,
@@ -125,6 +135,7 @@ pub struct Config {
     pub pid1: Pid1Config,
     pub services: Vec<String>,
     pub system_state: SystemStateConfig,
+    pub timers: TimersConfig,
     pub units: UnitsConfig,
 }
 
@@ -182,6 +193,10 @@ impl From<Ini> for Config {
             String::from("system-state"),
             String::from("enabled"),
         );
+
+        // [timers] section
+        config.timers.enabled =
+            read_config_bool(&ini_config, String::from("timers"), String::from("enabled"));
 
         // [units] section
         config.units.enabled =
@@ -272,6 +287,9 @@ bar.service
 [system-state]
 enabled = true
 
+[timers]
+enabled = true
+
 [units]
 enabled = true
 state_stats = true
@@ -342,6 +360,7 @@ output_format = json-flat
             pid1: Pid1Config { enabled: true },
             services: Vec::from([String::from("foo.service"), String::from("bar.service")]),
             system_state: SystemStateConfig { enabled: true },
+            timers: TimersConfig { enabled: true },
             units: UnitsConfig {
                 enabled: true,
                 state_stats: true,

--- a/src/json.rs
+++ b/src/json.rs
@@ -288,6 +288,9 @@ fn flatten_units(
             "timer_persistent_units" => {
                 flat_stats.insert(key, units_stats.timer_persistent_units.into());
             }
+            "timer_remain_after_elapse" => {
+                flat_stats.insert(key, units_stats.timer_remain_after_elapse.into());
+            }
             "total_units" => {
                 flat_stats.insert(key, units_stats.total_units.into());
             }
@@ -394,6 +397,7 @@ mod tests {
   "machines.foo.units.socket_units": 0,
   "machines.foo.units.target_units": 0,
   "machines.foo.units.timer_persistent_units": 0,
+  "machines.foo.units.timer_remain_after_elapse": 0,
   "machines.foo.units.timer_units": 0,
   "machines.foo.units.total_units": 0,
   "networkd.eth0.address_state": 3,
@@ -451,6 +455,7 @@ mod tests {
   "units.socket_units": 0,
   "units.target_units": 0,
   "units.timer_persistent_units": 0,
+  "units.timer_remain_after_elapse": 0,
   "units.timer_units": 0,
   "units.total_units": 0,
   "version": "255.7-1.fc40"
@@ -525,7 +530,7 @@ mod tests {
             &return_monitord_stats(),
             &String::from("JSON serialize failed"),
         );
-        assert_eq!(79, json_flat_map.len());
+        assert_eq!(81, json_flat_map.len());
     }
 
     #[test]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -4,10 +4,32 @@
 //! dbus / varlink etc.
 
 use anyhow::Result;
+use struct_field_names_as_array::FieldNamesAsArray;
 use tracing::error;
 use zbus::zvariant::OwnedObjectPath;
 
 use crate::units::SystemdUnitStats;
+
+#[derive(
+    serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, FieldNamesAsArray, PartialEq,
+)]
+
+/// Struct with all the timer specific statistics
+pub struct TimerStats {
+    pub accruacy_usec: u64,
+    pub fixed_random_delay: bool,
+    pub last_trigger_usec: u64,
+    pub last_trigger_usec_monotonic: u64,
+    pub next_elapse_usec_monotonic: u64,
+    pub next_elapse_usec_realtime: u64,
+    pub persistent: bool,
+    pub randomized_delay_usec: u64,
+    pub remain_after_elapse: bool,
+    pub service_unit_last_state_change_usec: u64,
+    pub service_unit_last_state_change_usec_monotonic: u64,
+}
+
+pub const TIMER_STATS_FIELD_NAMES: &[&str] = &TimerStats::FIELD_NAMES_AS_ARRAY;
 
 pub async fn collect_timer_stats(
     connection: &zbus::Connection,
@@ -24,32 +46,53 @@ pub async fn collect_timer_stats(
         String, // The job type as string
         OwnedObjectPath, // The job object path
     ),
-) -> Result<()> {
+) -> Result<TimerStats> {
     let pt = crate::dbus::zbus_timer::TimerProxy::builder(connection)
         .path(unit.6.clone())?
         .build()
         .await?;
-    match pt.persistent().await {
-        Ok(persistent_bool) => {
-            if persistent_bool {
-                stats.timer_persistent_units += 1;
-            }
-        }
-        Err(err) => error!(
-            "Failed to check if {} is persistent: {:?}",
-            &unit.0, err
-        ),
+    let mut timer_stats = TimerStats::default();
+
+    // Get service unit name to check when it last ran to ensure
+    // we are triggers the configured service with times set
+    let service_unit = pt.unit().await?;
+    if service_unit.is_empty() {
+        error!("{}: No service unit name found for timer", unit.0);
+        return Ok(timer_stats);
     }
-    match pt.remain_after_elapse().await {
-        Ok(remain_after_elapse) => {
-            if remain_after_elapse {
-                stats.timer_remain_after_elapse += 1;
-            }
-        }
-        Err(err) => error!(
-            "Failed to check if {} remains after elapse: {:?}",
-            &unit.0, err
-        ),
+
+    // Get the object path of the service unit
+    let mp = crate::dbus::zbus_systemd::ManagerProxy::new(connection).await?;
+    let service_unit_path = mp.get_unit(&service_unit).await?;
+
+    let up = crate::dbus::zbus_unit::UnitProxy::builder(connection)
+        .path(service_unit_path)?
+        .build()
+        .await?;
+
+    let persistent_bool = pt.persistent().await?;
+    if persistent_bool {
+        stats.timer_persistent_units += 1;
     }
-    Ok(())
+    timer_stats.persistent = persistent_bool;
+
+    let remain_after_elapse = pt.remain_after_elapse().await?;
+    if remain_after_elapse {
+        stats.timer_remain_after_elapse += 1;
+    }
+    timer_stats.remain_after_elapse = remain_after_elapse;
+
+    // Add all non counted stats
+    timer_stats.accruacy_usec = pt.accuracy_usec().await?;
+    timer_stats.fixed_random_delay = pt.fixed_random_delay().await?;
+    timer_stats.last_trigger_usec = pt.last_trigger_usec().await?;
+    timer_stats.last_trigger_usec_monotonic = pt.last_trigger_usec_monotonic().await?;
+    timer_stats.next_elapse_usec_monotonic = pt.next_elapse_usec_monotonic().await?;
+    timer_stats.next_elapse_usec_realtime = pt.next_elapse_usec_realtime().await?;
+    timer_stats.randomized_delay_usec = pt.randomized_delay_usec().await?;
+    timer_stats.service_unit_last_state_change_usec = up.state_change_timestamp().await?;
+    timer_stats.service_unit_last_state_change_usec_monotonic =
+        up.state_change_timestamp_monotonic().await?;
+
+    Ok(timer_stats)
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -36,7 +36,18 @@ pub async fn collect_timer_stats(
             }
         }
         Err(err) => error!(
-            "Failed to check if {} timer is persistent: {:?}",
+            "Failed to check if {} is persistent: {:?}",
+            &unit.0, err
+        ),
+    }
+    match pt.remain_after_elapse().await {
+        Ok(remain_after_elapse) => {
+            if remain_after_elapse {
+                stats.timer_remain_after_elapse += 1;
+            }
+        }
+        Err(err) => error!(
+            "Failed to check if {} remains after elapse: {:?}",
             &unit.0, err
         ),
     }

--- a/src/units.rs
+++ b/src/units.rs
@@ -47,6 +47,7 @@ pub struct SystemdUnitStats {
     pub target_units: u64,
     pub timer_units: u64,
     pub timer_persistent_units: u64,
+    pub timer_remain_after_elapse: u64,
     pub total_units: u64,
     pub service_stats: HashMap<String, ServiceStats>,
     pub unit_states: HashMap<String, UnitStates>,
@@ -489,6 +490,7 @@ mod tests {
             target_units: 0,
             timer_units: 0,
             timer_persistent_units: 0,
+            timer_remain_after_elapse: 0,
             total_units: 0,
             service_stats: HashMap::new(),
             unit_states: HashMap::from([(
@@ -560,6 +562,7 @@ mod tests {
             target_units: 0,
             timer_units: 1,
             timer_persistent_units: 0,
+            timer_remain_after_elapse: 0,
             total_units: 0,
             service_stats: HashMap::new(),
             unit_states: HashMap::new(),


### PR DESCRIPTION
Let's add some timer stats to collected values. We've had some bugs/issues with timers so it's been request we get some metrics around them.

People can then add this to timeseries databases and alarm if they calculate timers are not running enough ...

Here we:
- Collect all information systemd gives us specific to timers
  - Will be used to monitor timers are running as we'd hoped/configured
- Add collection of all values to timers.rs
  - Also pull service unit + it's last state change times too to check
     it triggers at the interval it should ...
- Move error reporting to units.rs for each timer unit
- Add "Flat JSON" support + update tests
  - Even test for machine support
- Add enable / disable config
  - Will add allow list + deny list in another diff
  - Want to share code already in use for other modules

```
[root@3f328e6a88bb repo]# cargo run -- -c monitord.conf | grep '\.timers\.'
   Compiling monitord v0.12.1 (/repo)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.43s
     Running `target/debug/monitord -c monitord.conf`
I0330 04:55:22.781206  8641 src/main.rs:28] monitord: Know how happy your systemd is! 😊
I0330 04:55:22.784276  8641 src/lib.rs:94] Starting stat collection run
I0330 04:55:22.795093  8641 src/lib.rs:182] stat collection run took 10ms
...
  "monitord.timers.dnf-makecache.timer.accruacy_usec": 60000000,
  "monitord.timers.dnf-makecache.timer.fixed_random_delay": 0,
  "monitord.timers.dnf-makecache.timer.last_trigger_usec": 1743644620422686,
  "monitord.timers.dnf-makecache.timer.last_trigger_usec_monotonic": 1200605963,
  "monitord.timers.dnf-makecache.timer.next_elapse_usec_monotonic": 12831031234,
  "monitord.timers.dnf-makecache.timer.next_elapse_usec_realtime": 0,
  "monitord.timers.dnf-makecache.timer.persistent": 0,
  "monitord.timers.dnf-makecache.timer.randomized_delay_usec": 3600000000,
  "monitord.timers.dnf-makecache.timer.remain_after_elapse": 1,
  "monitord.timers.dnf-makecache.timer.service_unit_last_state_change_usec": 1743644626165453,
  "monitord.timers.dnf-makecache.timer.service_unit_last_state_change_usec_monotonic": 1206348730,
  "monitord.timers.fstrim.timer.accruacy_usec": 3600000000,
  "monitord.timers.fstrim.timer.fixed_random_delay": 0,
  "monitord.timers.fstrim.timer.last_trigger_usec": 0,
  "monitord.timers.fstrim.timer.last_trigger_usec_monotonic": 0,
  "monitord.timers.fstrim.timer.next_elapse_usec_monotonic": 18446744073709551615,
  "monitord.timers.fstrim.timer.next_elapse_usec_realtime": 18446744073709551615,
  "monitord.timers.fstrim.timer.persistent": 1,
  "monitord.timers.fstrim.timer.randomized_delay_usec": 6000000000,
  "monitord.timers.fstrim.timer.remain_after_elapse": 1,
  "monitord.timers.fstrim.timer.service_unit_last_state_change_usec": 0,
  "monitord.timers.fstrim.timer.service_unit_last_state_change_usec_monotonic": 0,
  "monitord.timers.systemd-tmpfiles-clean.timer.accruacy_usec": 60000000,
  "monitord.timers.systemd-tmpfiles-clean.timer.fixed_random_delay": 0,
  "monitord.timers.systemd-tmpfiles-clean.timer.last_trigger_usec": 1743644388706253,
  "monitord.timers.systemd-tmpfiles-clean.timer.last_trigger_usec_monotonic": 968886257,
  "monitord.timers.systemd-tmpfiles-clean.timer.next_elapse_usec_monotonic": 87368890713,
  "monitord.timers.systemd-tmpfiles-clean.timer.next_elapse_usec_realtime": 0,
  "monitord.timers.systemd-tmpfiles-clean.timer.persistent": 0,
  "monitord.timers.systemd-tmpfiles-clean.timer.randomized_delay_usec": 0,
  "monitord.timers.systemd-tmpfiles-clean.timer.remain_after_elapse": 1,
  "monitord.timers.systemd-tmpfiles-clean.timer.service_unit_last_state_change_usec": 1743644388758879,
  "monitord.timers.systemd-tmpfiles-clean.timer.service_unit_last_state_change_usec_monotonic": 968938883,
...
```

cc: @anitazha - Does this look useful to pump into ODS/timeseries DB?