### PR TITLE
[timers] Call all DBUS calls in parallel

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -194,8 +194,8 @@ fn flatten_timers(
         for field_name in crate::timer::TimerStats::FIELD_NAMES_AS_ARRAY.iter() {
             let key = format!("{base_metric_name}.{timer_name}.{field_name}");
             match field_name.to_string().as_str() {
-                "accruacy_usec" => {
-                    flat_stats.insert(key, timer_stats.accruacy_usec.into());
+                "accuracy_usec" => {
+                    flat_stats.insert(key, timer_stats.accuracy_usec.into());
                 }
                 "fixed_random_delay" => {
                     flat_stats.insert(key, (timer_stats.fixed_random_delay as u64).into());
@@ -447,7 +447,7 @@ mod tests {
     const EXPECTED_FLAT_JSON: &str = r###"{
   "machines.foo.networkd.managed_interfaces": 0,
   "machines.foo.system-state": 0,
-  "machines.foo.timers.unittest.timer.accruacy_usec": 69,
+  "machines.foo.timers.unittest.timer.accuracy_usec": 69,
   "machines.foo.timers.unittest.timer.fixed_random_delay": 1,
   "machines.foo.timers.unittest.timer.last_trigger_usec": 69,
   "machines.foo.timers.unittest.timer.last_trigger_usec_monotonic": 69,
@@ -508,7 +508,7 @@ mod tests {
   "services.unittest.service.timeout_clean_usec": 0,
   "services.unittest.service.watchdog_usec": 0,
   "system-state": 3,
-  "timers.unittest.timer.accruacy_usec": 69,
+  "timers.unittest.timer.accuracy_usec": 69,
   "timers.unittest.timer.fixed_random_delay": 1,
   "timers.unittest.timer.last_trigger_usec": 69,
   "timers.unittest.timer.last_trigger_usec_monotonic": 69,
@@ -600,7 +600,7 @@ mod tests {
         );
         let timer_unit = String::from("unittest.timer");
         let timer_stats = timer::TimerStats {
-            accruacy_usec: 69,
+            accuracy_usec: 69,
             fixed_random_delay: true,
             last_trigger_usec: 69,
             last_trigger_usec_monotonic: 69,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -16,7 +16,7 @@ use crate::units::SystemdUnitStats;
 
 /// Struct with all the timer specific statistics
 pub struct TimerStats {
-    pub accruacy_usec: u64,
+    pub accuracy_usec: u64,
     pub fixed_random_delay: bool,
     pub last_trigger_usec: u64,
     pub last_trigger_usec_monotonic: u64,
@@ -84,7 +84,7 @@ pub async fn collect_timer_stats(
 
     // Grab all the other DBUS data async
     let (
-        accruacy_usec,
+        accuracy_usec,
         fixed_random_delay,
         last_trigger_usec,
         last_trigger_usec_monotonic,
@@ -105,7 +105,7 @@ pub async fn collect_timer_stats(
         pt.remain_after_elapse(),
     );
 
-    timer_stats.accruacy_usec = accruacy_usec?;
+    timer_stats.accuracy_usec = accuracy_usec?;
     timer_stats.fixed_random_delay = fixed_random_delay?;
     timer_stats.last_trigger_usec = last_trigger_usec?;
     timer_stats.last_trigger_usec_monotonic = last_trigger_usec_monotonic?;


### PR DESCRIPTION
- Call everything in parallel via tokio::join!
- Also only lookup service unit timers should a timer have a unit set
  - Not sure if it's possible to have a timer without a service but caters for it

Does not seems to be faster ... But I feel the code is cleaner.

Test:

```
cooper@cooper-fedora-MJ0J8MTZ:~/repos/monitord$ cargo build --release
cooper@cooper-fedora-MJ0J8MTZ:~/repos/monitord$ ./target/release/monitord -c monitord.conf | grep '\.timers' | head
...
I0404 11:50:37.162290 1850555 src/lib.rs:182] stat collection run took 80ms
...

cooper@cooper-fedora-MJ0J8MTZ:~/repos/monitord$ cargo build --release
cooper@cooper-fedora-MJ0J8MTZ:~/repos/monitord$ ./target/release/monitord -c monitord.conf | grep '\.timers' | head
...
I0404 11:51:50.310913 1852422 src/lib.rs:182] stat collection run took 81ms
...
```