### PR TITLE
Make units time_in_state optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,7 @@ pub struct UnitsConfig {
     pub state_stats: bool,
     pub state_stats_allowlist: Vec<String>,
     pub state_stats_blocklist: Vec<String>,
+    pub state_stats_time_in_state: bool,
 }
 impl Default for UnitsConfig {
     fn default() -> Self {
@@ -111,6 +112,7 @@ impl Default for UnitsConfig {
             state_stats: false,
             state_stats_allowlist: Vec::new(),
             state_stats_blocklist: Vec::new(),
+            state_stats_time_in_state: true,
         }
     }
 }
@@ -230,6 +232,11 @@ impl From<Ini> for Config {
                 .map(|s| s.to_string())
                 .collect();
         }
+        config.units.state_stats_time_in_state = read_config_bool(
+            &ini_config,
+            String::from("units"),
+            String::from("state_stats_time_in_state"),
+        );
 
         // [machines] section
         config.machines.enabled = read_config_bool(
@@ -311,6 +318,7 @@ bar.timer
 [units]
 enabled = true
 state_stats = true
+state_stats_time_in_state = true
 
 [units.state_stats.allowlist]
 foo.service
@@ -388,6 +396,7 @@ output_format = json-flat
                 state_stats: true,
                 state_stats_allowlist: Vec::from([String::from("foo.service")]),
                 state_stats_blocklist: Vec::from([String::from("bar.service")]),
+                state_stats_time_in_state: true,
             },
             machines: MachinesConfig {
                 enabled: true,

--- a/src/json.rs
+++ b/src/json.rs
@@ -268,7 +268,9 @@ fn flatten_unit_states(
                     }
                 },
                 "time_in_state_usecs" => {
-                    flat_stats.insert(key, unit_state_stats.time_in_state_usecs.into());
+                    if let Some(time_in_state_usecs) = unit_state_stats.time_in_state_usecs {
+                        flat_stats.insert(key, time_in_state_usecs.into());
+                    }
                 }
                 _ => {
                     debug!("Got a unhandled unit state: '{}'", field_name);
@@ -521,7 +523,6 @@ mod tests {
   "timers.unittest.timer.service_unit_last_state_change_usec_monotonic": 69,
   "unit_states.nvme\\x2dWDC_CL_SN730_SDBQNTY\\x2d512G\\x2d2020_37222H80070511\\x2dpart3.device.active_state": 1,
   "unit_states.nvme\\x2dWDC_CL_SN730_SDBQNTY\\x2d512G\\x2d2020_37222H80070511\\x2dpart3.device.load_state": 1,
-  "unit_states.nvme\\x2dWDC_CL_SN730_SDBQNTY\\x2d512G\\x2d2020_37222H80070511\\x2dpart3.device.time_in_state_usecs": 69,
   "unit_states.nvme\\x2dWDC_CL_SN730_SDBQNTY\\x2d512G\\x2d2020_37222H80070511\\x2dpart3.device.unhealthy": 0,
   "unit_states.unittest.service.active_state": 1,
   "unit_states.unittest.service.load_state": 1,
@@ -595,7 +596,7 @@ mod tests {
                 active_state: units::SystemdUnitActiveState::active,
                 load_state: units::SystemdUnitLoadState::loaded,
                 unhealthy: false,
-                time_in_state_usecs: 69,
+                time_in_state_usecs: Some(69),
             },
         );
         let timer_unit = String::from("unittest.timer");
@@ -632,7 +633,7 @@ mod tests {
                 active_state: units::SystemdUnitActiveState::active,
                 load_state: units::SystemdUnitLoadState::loaded,
                 unhealthy: false,
-                time_in_state_usecs: 69,
+                time_in_state_usecs: None,
             },
         );
         stats
@@ -644,7 +645,7 @@ mod tests {
             &return_monitord_stats(),
             &String::from("JSON serialize failed"),
         );
-        assert_eq!(103, json_flat_map.len());
+        assert_eq!(102, json_flat_map.len());
     }
 
     #[test]

--- a/src/units.rs
+++ b/src/units.rs
@@ -256,7 +256,7 @@ async fn get_time_in_state(
             Ok(Some(now - state_change_timestamp))
         }
         None => {
-            error!("No zbus connection passed, but time_in_state_secs enabled");
+            error!("No zbus connection passed, but time_in_state_usecs enabled");
             Ok(None)
         }
     }
@@ -292,7 +292,7 @@ pub async fn parse_state(
     let load_state = SystemdUnitLoadState::from_str(&unit.2.replace('-', "_"))
         .unwrap_or(SystemdUnitLoadState::unknown);
 
-    // Get the state_change_timestamp to determine time in seconds we've been in current state
+    // Get the state_change_timestamp to determine time in usecs we've been in current state
     let mut time_in_state_usecs: Option<u64> = None;
     if config.state_stats_time_in_state {
         time_in_state_usecs = get_time_in_state(connection, unit).await?;


### PR DESCRIPTION
- This collection is expensive (zbus call per unit)
- Add a bool to enable it or not in config
- To make it clear, represent the stat as optional to know when disabled
- If null, don't print in flat JSON

Test:
- Keep unittests passing
- Show we handle optional not seeing in flat JSON
  - Other formats will show null