### PR TITLE
Use zbus `method_timeout` instead of tokio timeouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ tracing = "0.1"
 tracing-core = "0.1"
 tracing-glog = "0.4"
 tracing-subscriber = "0.3"
-zbus = { version = "5.1.1", features = ["tokio"], default-features = false }
-zvariant = "5.1.0"
-zvariant_derive = "5.1.0"
+zbus = { version = "5.11.0", features = ["tokio"], default-features = false }
+zvariant = "5.7.0"
+zvariant_derive = "5.7.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = "0.15.1"

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -60,6 +60,7 @@ pub async fn update_machines_stats(
             leader_pid
         );
         let sdc = zbus::connection::Builder::address(container_address.as_str())?
+            .method_timeout(std::time::Duration::from_secs(config.monitord.dbus_timeout))
             .build()
             .await?;
         let mut join_set = tokio::task::JoinSet::new();


### PR DESCRIPTION
zbus version 5.11 added new `method_timeout` API. We should use it instead of custom tokio timeouts.