### PR TITLE
perf: make flatten* return Vec

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -84,7 +84,7 @@ fn flatten_pid1(
     let pid1_stats = match optional_pid1_stats {
         Some(ps) => ps,
         None => {
-            debug!("Skipping flatenning pid1 stats as we got None ...");
+            debug!("Skipping flattening pid1 stats as we got None ...");
             return Vec::new();
         }
     };


### PR DESCRIPTION
family of flatten functions is used to extend BTreeMap. Extend accepts any Iter, not only BTreeMap. As extend() does not take advantage of sorted order and flatten keys are unique, constructing and returning Vec is more efficient.