### PR TITLE
Add some very basic dbus_stats tests

### DIFF
--- a/src/dbus_stats.rs
+++ b/src/dbus_stats.rs
@@ -598,7 +598,7 @@ mod tests {
         // When user_stats=true, empty array should return Some(empty map)
         cfg.dbus_stats.user_stats = true;
         let empty_val = Value::Array(Array::from(Vec::<Value>::new()));
-        let owned = OwnedValue::try_from(empty_val).unwrap();
+        let owned = OwnedValue::try_from(empty_val).expect("should convert empty array");
         let parsed = parse_user_accounting(&cfg, &owned).expect("should parse empty");
         assert_eq!(parsed.len(), 0);
 


### PR DESCRIPTION
- Added tests for
  - `get_name_for_metric`
  - `get_u32/get_u32_vec`
  - `parse_peer_struct`
  - `cgroup_accounting` skip behavior

This is all I and AI could workout how to test sanely as I can't work how to mock the zvariant OwnedValue / &Value ...