### PR TITLE
Replace abandoned users crate with uzers fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tracing = "0.1"
 tracing-core = "0.1"
 tracing-glog = "0.4"
 tracing-subscriber = "0.3"
-users = "0.11"
+uzers = "0.12"
 zbus = { version = "5.11.0", features = ["tokio"], default-features = false }
 zvariant = "5.7.0"
 zvariant_derive = "5.7.0"

--- a/src/dbus_stats.rs
+++ b/src/dbus_stats.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use tokio::sync::RwLock;
 use tracing::error;
-use users::get_user_by_uid;
+use uzers::get_user_by_uid;
 use zbus::fdo::{DBusProxy, StatsProxy};
 use zbus::names::BusName;
 use zvariant::{Dict, OwnedValue, Value};


### PR DESCRIPTION
The `users` crate is no longer maintained. Replace it with `uzers`, a maintained fork that provides the same API.

Changes:
- Update Cargo.toml: users 0.11 -> uzers 0.12
- Update src/dbus_stats.rs: change import from users to uzers

Tested: cargo build succeeds, all 24 tests pass (cargo test)

[ Reason: the old users crate has an open RUSTSEC ]
