### PR TITLE
Add crates.io links to docs landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -229,6 +229,8 @@
 
     <ul>
       <li><a href="https://github.com/cooperlees/monitord">GitHub</a></li>
+      <li><a href="https://crates.io/crates/monitord">monitord on crates.io</a></li>
+      <li><a href="https://crates.io/crates/monitord-exporter">monitord-exporter on crates.io</a></li>
       <li><a href="monitord/index.html">Rust Docs</a></li>
     </ul>
 

--- a/landing_page.html
+++ b/landing_page.html
@@ -229,6 +229,8 @@
 
     <ul>
       <li><a href="https://github.com/cooperlees/monitord">GitHub</a></li>
+      <li><a href="https://crates.io/crates/monitord">monitord on crates.io</a></li>
+      <li><a href="https://crates.io/crates/monitord-exporter">monitord-exporter on crates.io</a></li>
       <li><a href="monitord/index.html">Rust Docs</a></li>
     </ul>
 


### PR DESCRIPTION
## Summary
- Add links to [monitord](https://crates.io/crates/monitord) and [monitord-exporter](https://crates.io/crates/monitord-exporter) on crates.io
- Links appear between GitHub and Rust Docs in the nav list
- Rebuilt docs included

## Test plan
- [ ] Verify links appear on the landing page
- [ ] Verify both crates.io links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)