### PR TITLE
Remove unused itertools dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ clap = { version = "4.5", features = ["derive", "std", "help"], default-features
 configparser = { version = "3.1.0", features = ["indexmap"] }
 indexmap = "2.9"
 int-enum = "1.1"
-itertools = "0.14.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"


### PR DESCRIPTION
## Summary
- Remove `itertools` from Cargo.toml — it was never imported in any source file
- Reduces compile time and binary size

## Test plan
- [x] `cargo check` passes
- [x] All 23 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)