### PR TITLE
Use &str instead of &String in json.rs function signatures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn print_stats(
         ),
         config::MonitordOutputFormat::JsonFlat => println!(
             "{}",
-            json::flatten(stats, &key_prefix.to_string()).expect("Invalid JSON serialization")
+            json::flatten(stats, key_prefix).expect("Invalid JSON serialization")
         ),
         config::MonitordOutputFormat::JsonPretty => println!(
             "{}",


### PR DESCRIPTION
## Summary
- Change all `flatten_*` functions and `gen_base_metric_key` from `&String` to `&str` parameters
- Remove unnecessary `&String::from(...)` allocations at call sites in `json.rs` and `lib.rs`
- Remove redundant `field_name.to_string().as_str()` in `flatten_units` — `field_name` is already `&str`

## Test plan
- [x] All 23 unit tests pass
- [x] JSON flattening tests (map, flat, prefixed) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)