### PR TITLE
Use Arc<Config> instead of cloning config per collection cycle

### DIFF
--- a/src/dbus_stats.rs
+++ b/src/dbus_stats.rs
@@ -482,7 +482,7 @@ pub async fn parse_dbus_stats(
 
 /// Async wrapper than can update dbus stats when passed a locked struct
 pub async fn update_dbus_stats(
-    config: crate::config::Config,
+    config: Arc<crate::config::Config>,
     connection: zbus::Connection,
     locked_machine_stats: Arc<RwLock<MachineStats>>,
 ) -> anyhow::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ pub async fn stat_collector(
         collect_interval_ms = (config.monitord.daemon_stats_refresh_secs * 1000).into();
     }
 
+    let config = Arc::new(config);
     let locked_monitord_stats: Arc<RwLock<MonitordStats>> =
         maybe_locked_stats.unwrap_or(Arc::new(RwLock::new(MonitordStats::default())));
     let locked_machine_stats: Arc<RwLock<MachineStats>> =
@@ -134,7 +135,7 @@ pub async fn stat_collector(
         // Run service collectors if there are services listed in config
         if config.units.enabled {
             join_set.spawn(crate::units::update_unit_stats(
-                config.clone(),
+                Arc::clone(&config),
                 sdc.clone(),
                 locked_machine_stats.clone(),
             ));
@@ -142,7 +143,7 @@ pub async fn stat_collector(
 
         if config.machines.enabled {
             join_set.spawn(crate::machines::update_machines_stats(
-                config.clone(),
+                Arc::clone(&config),
                 sdc.clone(),
                 locked_monitord_stats.clone(),
             ));
@@ -150,7 +151,7 @@ pub async fn stat_collector(
 
         if config.dbus_stats.enabled {
             join_set.spawn(crate::dbus_stats::update_dbus_stats(
-                config.clone(),
+                Arc::clone(&config),
                 sdc.clone(),
                 locked_machine_stats.clone(),
             ));

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -43,7 +43,7 @@ pub async fn get_machines(
 }
 
 pub async fn update_machines_stats(
-    config: crate::config::Config,
+    config: Arc<crate::config::Config>,
     connection: zbus::Connection,
     locked_monitord_stats: Arc<RwLock<MonitordStats>>,
 ) -> anyhow::Result<()> {
@@ -95,7 +95,7 @@ pub async fn update_machines_stats(
 
         if config.units.enabled {
             join_set.spawn(crate::units::update_unit_stats(
-                config.clone(),
+                Arc::clone(&config),
                 sdc.clone(),
                 locked_machine_stats.clone(),
             ));
@@ -103,7 +103,7 @@ pub async fn update_machines_stats(
 
         if config.dbus_stats.enabled {
             join_set.spawn(crate::dbus_stats::update_dbus_stats(
-                config.clone(),
+                Arc::clone(&config),
                 sdc.clone(),
                 locked_machine_stats.clone(),
             ));

--- a/src/units.rs
+++ b/src/units.rs
@@ -539,7 +539,7 @@ pub async fn parse_unit_state(
 
 /// Async wrapper than can update uni stats when passed a locked struct
 pub async fn update_unit_stats(
-    config: crate::config::Config,
+    config: Arc<crate::config::Config>,
     connection: zbus::Connection,
     locked_machine_stats: Arc<RwLock<MachineStats>>,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- Wrap `Config` in `Arc` in `stat_collector` and pass `Arc::clone` to spawned tasks
- Eliminates 5-7 deep clones of the entire `Config` struct per collection cycle
- Updated `update_unit_stats`, `update_machines_stats`, and `update_dbus_stats` signatures to accept `Arc<Config>`

## Test plan
- [x] All 23 unit tests pass
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)