### PR TITLE
Use HashSet for allowlist/blocklist lookups instead of Vec

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -86,15 +87,15 @@ impl Default for SystemStateConfig {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TimersConfig {
     pub enabled: bool,
-    pub allowlist: Vec<String>,
-    pub blocklist: Vec<String>,
+    pub allowlist: HashSet<String>,
+    pub blocklist: HashSet<String>,
 }
 impl Default for TimersConfig {
     fn default() -> Self {
         TimersConfig {
             enabled: true,
-            allowlist: Vec::new(),
-            blocklist: Vec::new(),
+            allowlist: HashSet::new(),
+            blocklist: HashSet::new(),
         }
     }
 }
@@ -103,8 +104,8 @@ impl Default for TimersConfig {
 pub struct UnitsConfig {
     pub enabled: bool,
     pub state_stats: bool,
-    pub state_stats_allowlist: Vec<String>,
-    pub state_stats_blocklist: Vec<String>,
+    pub state_stats_allowlist: HashSet<String>,
+    pub state_stats_blocklist: HashSet<String>,
     pub state_stats_time_in_state: bool,
 }
 impl Default for UnitsConfig {
@@ -112,8 +113,8 @@ impl Default for UnitsConfig {
         UnitsConfig {
             enabled: true,
             state_stats: false,
-            state_stats_allowlist: Vec::new(),
-            state_stats_blocklist: Vec::new(),
+            state_stats_allowlist: HashSet::new(),
+            state_stats_blocklist: HashSet::new(),
             state_stats_time_in_state: true,
         }
     }
@@ -122,15 +123,15 @@ impl Default for UnitsConfig {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MachinesConfig {
     pub enabled: bool,
-    pub allowlist: Vec<String>,
-    pub blocklist: Vec<String>,
+    pub allowlist: HashSet<String>,
+    pub blocklist: HashSet<String>,
 }
 impl Default for MachinesConfig {
     fn default() -> Self {
         MachinesConfig {
             enabled: true,
-            allowlist: Vec::new(),
-            blocklist: Vec::new(),
+            allowlist: HashSet::new(),
+            blocklist: HashSet::new(),
         }
     }
 }
@@ -161,7 +162,7 @@ pub struct Config {
     pub monitord: MonitordConfig,
     pub networkd: NetworkdConfig,
     pub pid1: Pid1Config,
-    pub services: Vec<String>,
+    pub services: HashSet<String>,
     pub system_state: SystemStateConfig,
     pub timers: TimersConfig,
     pub units: UnitsConfig,
@@ -435,24 +436,24 @@ output_format = json-flat
                 link_state_dir: "/links".into(),
             },
             pid1: Pid1Config { enabled: true },
-            services: Vec::from([String::from("foo.service"), String::from("bar.service")]),
+            services: HashSet::from([String::from("foo.service"), String::from("bar.service")]),
             system_state: SystemStateConfig { enabled: true },
             timers: TimersConfig {
                 enabled: true,
-                allowlist: Vec::from([String::from("foo.timer")]),
-                blocklist: Vec::from([String::from("bar.timer")]),
+                allowlist: HashSet::from([String::from("foo.timer")]),
+                blocklist: HashSet::from([String::from("bar.timer")]),
             },
             units: UnitsConfig {
                 enabled: true,
                 state_stats: true,
-                state_stats_allowlist: Vec::from([String::from("foo.service")]),
-                state_stats_blocklist: Vec::from([String::from("bar.service")]),
+                state_stats_allowlist: HashSet::from([String::from("foo.service")]),
+                state_stats_blocklist: HashSet::from([String::from("bar.service")]),
                 state_stats_time_in_state: true,
             },
             machines: MachinesConfig {
                 enabled: true,
-                allowlist: Vec::from([String::from("foo"), String::from("bar")]),
-                blocklist: Vec::from([String::from("foo2")]),
+                allowlist: HashSet::from([String::from("foo"), String::from("bar")]),
+                blocklist: HashSet::from([String::from("foo2")]),
             },
             dbus_stats: DBusStatsConfig {
                 enabled: true,

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -9,8 +10,8 @@ use crate::MonitordStats;
 
 pub fn filter_machines(
     machines: Vec<crate::dbus::zbus_machines::ListedMachine>,
-    allowlist: &[String],
-    blocklist: &[String],
+    allowlist: &HashSet<String>,
+    blocklist: &HashSet<String>,
 ) -> Vec<crate::dbus::zbus_machines::ListedMachine> {
     machines
         .into_iter()
@@ -140,6 +141,7 @@ pub async fn update_machines_stats(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use zbus::zvariant::OwnedObjectPath;
 
     #[test]
@@ -164,8 +166,8 @@ mod tests {
                 path: OwnedObjectPath::try_from("/sample/object").unwrap(),
             },
         ];
-        let allowlist = vec!["foo".to_string(), "baz".to_string()];
-        let blocklist = vec!["bar".to_string()];
+        let allowlist = HashSet::from(["foo".to_string(), "baz".to_string()]);
+        let blocklist = HashSet::from(["bar".to_string()]);
 
         let filtered = super::filter_machines(machines, &allowlist, &blocklist);
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -554,6 +554,7 @@ pub async fn update_unit_stats(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
     use strum::IntoEnumIterator;
 
     fn get_unit_file() -> ListedUnit {
@@ -651,7 +652,7 @@ mod tests {
         assert_eq!(expected_stats, stats);
 
         // Create an allow list
-        config.state_stats_allowlist = Vec::from([test_unit_name.clone()]);
+        config.state_stats_allowlist = HashSet::from([test_unit_name.clone()]);
 
         // test no blocklist and only allow list - Should equal the same as no lists above
         let mut allowlist_stats = SystemdUnitStats::default();
@@ -659,7 +660,7 @@ mod tests {
         assert_eq!(expected_stats, allowlist_stats);
 
         // Now add a blocklist
-        config.state_stats_blocklist = Vec::from([test_unit_name]);
+        config.state_stats_blocklist = HashSet::from([test_unit_name]);
 
         // test blocklist with allow list (show it's preferred)
         let mut blocklist_stats = SystemdUnitStats::default();


### PR DESCRIPTION
## Summary
- Change `services`, `timers.allowlist`, `timers.blocklist`, `units.state_stats_allowlist`, `units.state_stats_blocklist`, `machines.allowlist`, and `machines.blocklist` from `Vec<String>` to `HashSet<String>`
- O(1) lookups instead of O(n) when iterating over all systemd units
- Updated all tests to use `HashSet::from()`

## Test plan
- [x] All 23 unit tests pass
- [x] Config parsing, machine filtering, and unit state tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)