### PR TITLE
Replace panics with Result in config parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,5 +33,5 @@ async fn main() -> anyhow::Result<()> {
         .load(args.config)
         .map_err(|e| anyhow::anyhow!("Config error: {:?}", e))?;
 
-    monitord::stat_collector(config.into(), None, true).await
+    monitord::stat_collector(config.try_into()?, None, true).await
 }


### PR DESCRIPTION
## Summary
- Change `From<Ini>` to `TryFrom<Ini>` for `Config` so config errors propagate instead of panicking
- `read_config_bool` now returns `anyhow::Result<bool>` instead of using `panic!()` on parse errors
- `output_format` parsing uses `context()` instead of `expect()`
- Also takes the `&str` parameter improvement from #143 (both changes to `read_config_bool`)
- Added `test_invalid_config_returns_error` test to verify graceful error handling

## Test plan
- [x] All 24 unit tests pass (1 new test)
- [x] New test verifies invalid bool values return `Err` instead of panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)