### PR TITLE
Add custom thiserror error types to all modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,17 @@ use std::collections::HashMap;
 use std::time::Duration;
 use std::time::Instant;
 
+use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
+
+#[derive(Error, Debug)]
+pub enum MonitordError {
+    #[error("D-Bus connection error: {0}")]
+    ZbusError(#[from] zbus::Error),
+}
 
 pub mod config;
 pub(crate) mod dbus;
@@ -77,7 +84,7 @@ pub async fn stat_collector(
     config: config::Config,
     maybe_locked_stats: Option<Arc<RwLock<MonitordStats>>>,
     output_stats: bool,
-) -> anyhow::Result<()> {
+) -> Result<(), MonitordError> {
     let mut collect_interval_ms: u128 = 0;
     if config.monitord.daemon {
         collect_interval_ms = (config.monitord.daemon_stats_refresh_secs * 1000).into();

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -2,11 +2,18 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{debug, error};
 
 use crate::MachineStats;
 use crate::MonitordStats;
+
+#[derive(Error, Debug)]
+pub enum MonitordMachinesError {
+    #[error("Machines D-Bus error: {0}")]
+    ZbusError(#[from] zbus::Error),
+}
 
 pub fn filter_machines(
     machines: Vec<crate::dbus::zbus_machines::ListedMachine>,
@@ -24,7 +31,7 @@ pub fn filter_machines(
 pub async fn get_machines(
     connection: &zbus::Connection,
     config: &crate::config::Config,
-) -> Result<HashMap<String, u32>, zbus::Error> {
+) -> Result<HashMap<String, u32>, MonitordMachinesError> {
     let c = crate::dbus::zbus_machines::ManagerProxy::new(connection).await?;
     let mut results = HashMap::<String, u32>::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,5 +33,5 @@ async fn main() -> anyhow::Result<()> {
         .load(args.config)
         .map_err(|e| anyhow::anyhow!("Config error: {:?}", e))?;
 
-    monitord::stat_collector(config.try_into()?, None, true).await
+    Ok(monitord::stat_collector(config.try_into()?, None, true).await?)
 }

--- a/src/networkd.rs
+++ b/src/networkd.rs
@@ -8,15 +8,25 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anyhow::Result;
 use int_enum::IntEnum;
 use serde_repr::*;
 use strum_macros::EnumIter;
 use strum_macros::EnumString;
+use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::error;
 
 use crate::MachineStats;
+
+#[derive(Error, Debug)]
+pub enum MonitordNetworkdError {
+    #[error("Networkd D-Bus error: {0}")]
+    ZbusError(#[from] zbus::Error),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("Parse error: {0}")]
+    ParseError(String),
+}
 
 /// Enumeration of networkd address states
 #[allow(non_camel_case_types)]
@@ -212,7 +222,7 @@ pub struct InterfaceState {
 /// Get interface id + name from dbus list_links API
 async fn get_interface_links(
     connection: &zbus::Connection,
-) -> Result<HashMap<i32, String>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<HashMap<i32, String>, MonitordNetworkdError> {
     let p = crate::dbus::zbus_networkd::ManagerProxy::new(connection).await?;
     let links = p.list_links().await?;
     let mut link_int_to_name: HashMap<i32, String> = HashMap::new();
@@ -236,7 +246,7 @@ pub fn parse_interface_stats(
     interface_state_str: &str,
     interface_id: i32,
     interface_id_to_name: &HashMap<i32, String>,
-) -> Result<InterfaceState, String> {
+) -> Result<InterfaceState, MonitordNetworkdError> {
     let mut interface_state = InterfaceState::default();
 
     // Pull interface name out of list_links generated HashMap (once, not per line)
@@ -297,7 +307,7 @@ pub async fn parse_interface_state_files(
     states_path: &PathBuf,
     maybe_network_int_to_name: Option<HashMap<i32, String>>,
     maybe_connection: Option<&zbus::Connection>,
-) -> Result<NetworkdState, std::io::Error> {
+) -> Result<NetworkdState, MonitordNetworkdError> {
     let mut managed_interface_count: u64 = 0;
     let mut interfaces_state = vec![];
 
@@ -448,7 +458,7 @@ MDNS=no
     }
 
     #[tokio::test]
-    async fn test_parse_interface_state_files() -> Result<()> {
+    async fn test_parse_interface_state_files() -> Result<(), MonitordNetworkdError> {
         let expected_files = NetworkdState {
             interfaces_state: vec![return_expected_interface_state()],
             managed_interfaces: 1,
@@ -475,7 +485,7 @@ MDNS=no
     }
 
     #[test]
-    fn test_enums_to_ints() -> Result<()> {
+    fn test_enums_to_ints() -> Result<(), MonitordNetworkdError> {
         assert_eq!(3, AddressState::routable as u64);
         let carrier_state_int: u8 = u8::from(CarrierState::degraded_carrier);
         assert_eq!(4, carrier_state_int);

--- a/src/pid1.rs
+++ b/src/pid1.rs
@@ -8,10 +8,20 @@ use std::sync::Arc;
 
 #[cfg(target_os = "linux")]
 use procfs::process::Process;
+use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::error;
 
 use crate::MachineStats;
+
+#[derive(Error, Debug)]
+pub enum MonitordPid1Error {
+    #[cfg(target_os = "linux")]
+    #[error("Procfs error: {0}")]
+    ProcfsError(#[from] procfs::ProcError),
+    #[error("Integer conversion error: {0}")]
+    IntConversion(#[from] std::num::TryFromIntError),
+}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, PartialEq)]
 pub struct Pid1Stats {
@@ -24,7 +34,7 @@ pub struct Pid1Stats {
 
 /// Get procfs info on pid 1 - <https://manpages.debian.org/buster/manpages/procfs.5.en.html>
 #[cfg(target_os = "linux")]
-pub fn get_pid_stats(pid: i32) -> anyhow::Result<Pid1Stats> {
+pub fn get_pid_stats(pid: i32) -> Result<Pid1Stats, MonitordPid1Error> {
     let bytes_per_page = procfs::page_size();
     let ticks_per_second = procfs::ticks_per_second();
 
@@ -48,7 +58,7 @@ pub fn get_pid_stats(pid: i32) -> anyhow::Result<Pid1Stats> {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn get_pid_stats(_pid: i32) -> anyhow::Result<Pid1Stats> {
+pub fn get_pid_stats(_pid: i32) -> Result<Pid1Stats, MonitordPid1Error> {
     error!("pid1 stats not supported on this OS");
     Ok(Pid1Stats::default())
 }
@@ -81,7 +91,7 @@ pub mod tests {
     use super::*;
 
     #[test]
-    pub fn test_get_stats() -> anyhow::Result<()> {
+    pub fn test_get_stats() -> Result<(), MonitordPid1Error> {
         let pid1_stats = get_pid_stats(1)?;
         assert!(pid1_stats.tasks > 0);
         Ok(())

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -3,11 +3,17 @@
 //! All timer related logic goes here. This will be hitting timer specific
 //! dbus / varlink etc.
 
-use anyhow::Result;
 use struct_field_names_as_array::FieldNamesAsArray;
+use thiserror::Error;
 use tracing::error;
 
 use crate::units::SystemdUnitStats;
+
+#[derive(Error, Debug)]
+pub enum MonitordTimerError {
+    #[error("Timer D-Bus error: {0}")]
+    ZbusError(#[from] zbus::Error),
+}
 
 #[derive(
     serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, FieldNamesAsArray, PartialEq,
@@ -34,7 +40,7 @@ pub async fn collect_timer_stats(
     connection: &zbus::Connection,
     stats: &mut SystemdUnitStats,
     unit: &crate::units::ListedUnit,
-) -> Result<TimerStats> {
+) -> Result<TimerStats, MonitordTimerError> {
     let mut timer_stats = TimerStats::default();
 
     let pt = crate::dbus::zbus_timer::TimerProxy::builder(connection)


### PR DESCRIPTION
## Summary
- Add per-module `thiserror` error enums to all public functions, replacing inconsistent `anyhow::Result`, `Box<dyn Error>`, `Result<_, String>`, and `Result<_, io::Error>` usage
- Refine existing `MonitordSystemError` by removing `GenericError(anyhow::Error)` and adding `VersionParseError` and `IntParseError` variants
- Internal `update_*` wrappers and `main()` retain `anyhow::Result` since their errors are logged and swallowed

## New error types
| Module | Error Type | Variants |
|--------|-----------|----------|
| `timer.rs` | `MonitordTimerError` | `ZbusError` |
| `pid1.rs` | `MonitordPid1Error` | `ProcfsError`, `IntConversion` |
| `dbus_stats.rs` | `MonitordDbusStatsError` | `ZbusError`, `FdoError` |
| `machines.rs` | `MonitordMachinesError` | `ZbusError` |
| `networkd.rs` | `MonitordNetworkdError` | `ZbusError`, `IoError`, `ParseError` |
| `config.rs` | `MonitordConfigError` | `InvalidValue`, `MissingKey` |
| `units.rs` | `MonitordUnitsError` | `ZbusError`, `IntConversion`, `SystemTimeError` |
| `lib.rs` | `MonitordError` | `ZbusError` |

## Test plan
- [x] `cargo build` compiles clean
- [x] `cargo test` — all 25 tests pass
- [x] `cargo fmt --check` — no formatting issues
- [x] `cargo clippy` — no warnings

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)