### PR TITLE
Add custom thiserror error types to all modules

### DIFF
--- a/src/dbus_stats.rs
+++ b/src/dbus_stats.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::io;
 use std::sync::Arc;
 
-use anyhow::Result;
+use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::error;
 use uzers::get_user_by_uid;
@@ -16,6 +16,14 @@ use zbus::names::BusName;
 use zvariant::{Dict, OwnedValue, Value};
 
 use crate::MachineStats;
+
+#[derive(Error, Debug)]
+pub enum MonitordDbusStatsError {
+    #[error("D-Bus error: {0}")]
+    ZbusError(#[from] zbus::Error),
+    #[error("D-Bus fdo error: {0}")]
+    FdoError(#[from] zbus::fdo::Error),
+}
 
 // Unfortunately, various DBus daemons (ex: dbus-broker and dbus-daemon)
 // represent stats differently. Moreover, the stats vary across versions of the same daemon.
@@ -472,7 +480,7 @@ fn parse_user_accounting(
 
 async fn get_well_known_to_peer_names(
     dbus_proxy: &DBusProxy<'_>,
-) -> Result<HashMap<String, String>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<HashMap<String, String>, MonitordDbusStatsError> {
     let dbus_names = dbus_proxy.list_names().await?;
     let mut result = HashMap::new();
 
@@ -492,7 +500,7 @@ async fn get_well_known_to_peer_names(
 pub async fn parse_dbus_stats(
     config: &crate::config::Config,
     connection: &zbus::Connection,
-) -> Result<DBusStats, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<DBusStats, MonitordDbusStatsError> {
     let dbus_proxy = DBusProxy::new(connection).await?;
     let well_known_to_peer_names = get_well_known_to_peer_names(&dbus_proxy).await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,17 @@ use std::collections::HashMap;
 use std::time::Duration;
 use std::time::Instant;
 
+use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
+
+#[derive(Error, Debug)]
+pub enum MonitordError {
+    #[error("D-Bus connection error: {0}")]
+    ZbusError(#[from] zbus::Error),
+}
 
 pub mod config;
 pub(crate) mod dbus;
@@ -91,7 +98,7 @@ pub async fn stat_collector(
     config: config::Config,
     maybe_locked_stats: Option<Arc<RwLock<MonitordStats>>>,
     output_stats: bool,
-) -> anyhow::Result<()> {
+) -> Result<(), MonitordError> {
     let mut collect_interval_ms: u128 = 0;
     if config.monitord.daemon {
         collect_interval_ms = (config.monitord.daemon_stats_refresh_secs * 1000).into();

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -2,11 +2,18 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{debug, error};
 
 use crate::MachineStats;
 use crate::MonitordStats;
+
+#[derive(Error, Debug)]
+pub enum MonitordMachinesError {
+    #[error("Machines D-Bus error: {0}")]
+    ZbusError(#[from] zbus::Error),
+}
 
 pub fn filter_machines(
     machines: Vec<crate::dbus::zbus_machines::ListedMachine>,
@@ -24,7 +31,7 @@ pub fn filter_machines(
 pub async fn get_machines(
     connection: &zbus::Connection,
     config: &crate::config::Config,
-) -> Result<HashMap<String, u32>, zbus::Error> {
+) -> Result<HashMap<String, u32>, MonitordMachinesError> {
     let c = crate::dbus::zbus_machines::ManagerProxy::new(connection).await?;
     let mut results = HashMap::<String, u32>::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,5 +33,5 @@ async fn main() -> anyhow::Result<()> {
         .load(args.config)
         .map_err(|e| anyhow::anyhow!("Config error: {:?}", e))?;
 
-    monitord::stat_collector(config.try_into()?, None, true).await
+    Ok(monitord::stat_collector(config.try_into()?, None, true).await?)
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -7,8 +7,6 @@ use std::convert::TryInto;
 use std::fmt;
 use std::sync::Arc;
 
-use anyhow::anyhow;
-use anyhow::Context;
 use int_enum::IntEnum;
 use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
@@ -22,10 +20,12 @@ use crate::MachineStats;
 
 #[derive(Error, Debug)]
 pub enum MonitordSystemError {
-    #[error("monitord::system failed: {0:#}")]
-    GenericError(#[from] anyhow::Error),
     #[error("Unable to connect to DBUS via zbus: {0:#}")]
     ZbusError(#[from] zbus::Error),
+    #[error("Version parse error: {0}")]
+    VersionParseError(String),
+    #[error("Integer parse error: {0}")]
+    IntParseError(#[from] std::num::ParseIntError),
 }
 
 /// Overall system state reported by the systemd manager (PID 1).
@@ -107,12 +107,11 @@ impl TryFrom<String> for SystemdVersion {
         let split_count = parts.clone().count();
         let major = parts
             .next()
-            .with_context(|| "No valid major version")?
-            .parse::<u32>()
-            .with_context(|| format!("Failed to parse major version: {:?}", s))?;
+            .ok_or_else(|| MonitordSystemError::VersionParseError("No valid major version".into()))?
+            .parse::<u32>()?;
         let minor = parts
             .next()
-            .with_context(|| "No valid minor version")?
+            .ok_or_else(|| MonitordSystemError::VersionParseError("No valid minor version".into()))?
             .to_string();
         let mut revision = None;
         if split_count > 3 {
@@ -163,7 +162,7 @@ pub async fn update_system_stats(
     let mut machine_stats = locked_machine_stats.write().await;
     machine_stats.system_state = crate::system::get_system_state(&connection)
         .await
-        .map_err(|e| anyhow!("Error getting system state: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Error getting system state: {:?}", e))?;
     Ok(())
 }
 
@@ -173,10 +172,7 @@ pub async fn get_version(
     let p = crate::dbus::zbus_systemd::ManagerProxy::new(connection)
         .await
         .map_err(MonitordSystemError::ZbusError)?;
-    let version_string = p
-        .version()
-        .await
-        .with_context(|| "Unable to get systemd version string".to_string())?;
+    let version_string = p.version().await?;
     version_string.try_into()
 }
 
@@ -188,14 +184,13 @@ pub async fn update_version(
     let mut machine_stats = locked_machine_stats.write().await;
     machine_stats.version = crate::system::get_version(&connection)
         .await
-        .map_err(|e| anyhow!("Error getting systemd version: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Error getting systemd version: {:?}", e))?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::Result;
 
     #[test]
     fn test_display_struct() {
@@ -206,7 +201,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parsing_systemd_versions() -> Result<()> {
+    fn test_parsing_systemd_versions() -> Result<(), MonitordSystemError> {
         let parsed: SystemdVersion = "969.1.69.fc69".to_string().try_into()?;
         assert_eq!(
             SystemdVersion::new(969, String::from("1"), Some(69), String::from("fc69")),

--- a/src/units.rs
+++ b/src/units.rs
@@ -9,17 +9,27 @@ use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
-use anyhow::Result;
 use int_enum::IntEnum;
 use serde_repr::*;
 use struct_field_names_as_array::FieldNamesAsArray;
 use strum_macros::EnumIter;
 use strum_macros::EnumString;
+use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::debug;
 use tracing::error;
 use zbus::zvariant::ObjectPath;
 use zbus::zvariant::OwnedObjectPath;
+
+#[derive(Error, Debug)]
+pub enum MonitordUnitsError {
+    #[error("Units D-Bus error: {0}")]
+    ZbusError(#[from] zbus::Error),
+    #[error("Integer conversion error: {0}")]
+    IntConversion(#[from] std::num::TryFromIntError),
+    #[error("System time error: {0}")]
+    SystemTimeError(#[from] std::time::SystemTimeError),
+}
 
 use crate::timer::TimerStats;
 use crate::MachineStats;
@@ -275,7 +285,7 @@ async fn parse_service(
     connection: &zbus::Connection,
     name: &str,
     object_path: &OwnedObjectPath,
-) -> Result<ServiceStats> {
+) -> Result<ServiceStats, MonitordUnitsError> {
     debug!("Parsing service {} stats", name);
 
     let sp = crate::dbus::zbus_service::ServiceProxy::builder(connection)
@@ -366,7 +376,7 @@ pub fn is_unit_unhealthy(
 async fn get_time_in_state(
     connection: Option<&zbus::Connection>,
     unit: &ListedUnit,
-) -> Result<Option<u64>> {
+) -> Result<Option<u64>, MonitordUnitsError> {
     match connection {
         Some(c) => {
             let up = crate::dbus::zbus_unit::UnitProxy::builder(c)
@@ -399,7 +409,7 @@ pub async fn parse_state(
     unit: &ListedUnit,
     config: &crate::config::UnitsConfig,
     connection: Option<&zbus::Connection>,
-) -> Result<()> {
+) -> Result<(), MonitordUnitsError> {
     if config.state_stats_blocklist.contains(&unit.name) {
         debug!("Skipping state stats for {} due to blocklist", &unit.name);
         return Ok(());
@@ -472,7 +482,7 @@ fn parse_unit(stats: &mut SystemdUnitStats, unit: &ListedUnit) {
 pub async fn parse_unit_state(
     config: &crate::config::Config,
     connection: &zbus::Connection,
-) -> Result<SystemdUnitStats, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<SystemdUnitStats, MonitordUnitsError> {
     if !config.units.state_stats_allowlist.is_empty() {
         debug!(
             "Using unit state allowlist: {:?}",
@@ -615,7 +625,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_state_parse() -> Result<()> {
+    async fn test_state_parse() -> Result<(), MonitordUnitsError> {
         let test_unit_name = String::from("apport-autoreport.timer");
         let expected_stats = SystemdUnitStats {
             active_units: 0,


### PR DESCRIPTION
## Summary
- Add per-module `thiserror` error enums to all public functions, replacing inconsistent `anyhow::Result`, `Box<dyn Error>`, `Result<_, String>`, and `Result<_, io::Error>` usage
- Refine existing `MonitordSystemError` by removing `GenericError(anyhow::Error)` and adding `VersionParseError` and `IntParseError` variants
- Internal `update_*` wrappers and `main()` retain `anyhow::Result` since their errors are logged and swallowed
- Removed unused `ParseError` variant from `MonitordNetworkdError` (per Copilot review on #151)

## New error types
| Module | Error Type | Variants |
|--------|-----------|----------|
| `timer.rs` | `MonitordTimerError` | `ZbusError` |
| `pid1.rs` | `MonitordPid1Error` | `ProcfsError`, `IntConversion` |
| `dbus_stats.rs` | `MonitordDbusStatsError` | `ZbusError`, `FdoError` |
| `machines.rs` | `MonitordMachinesError` | `ZbusError` |
| `networkd.rs` | `MonitordNetworkdError` | `ZbusError`, `IoError` |
| `config.rs` | `MonitordConfigError` | `InvalidValue`, `MissingKey` |
| `units.rs` | `MonitordUnitsError` | `ZbusError`, `IntConversion`, `SystemTimeError` |
| `lib.rs` | `MonitordError` | `ZbusError` |

## Test plan
- [x] `cargo build` compiles clean
- [x] `cargo test` — all 24 tests pass
- [x] `cargo fmt --check` — no formatting issues
- [x] `cargo clippy` — no warnings

Closes #53
Supersedes #151 (rebased on main, resolved conflicts, applied review feedback)

Original work by @jpaussa
