### PR TITLE
Add allowlist/blocklist filtering to boot blame module (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ enabled = false
 # Number of slowest units to report
 num_slowest_units = 5
 
+# Optional: only include specific units in boot blame (if empty, all units are checked)
+# Same rules apply as state_stats lists above
+[boot.allowlist]
+# slow-startup.service
+
+# Optional: exclude specific units from boot blame
+[boot.blocklist]
+# noisy-but-expected.service
+
 # Unit verification using systemd-analyze verify
 # Disabled by default as it can be slow on large systems
 [verify]

--- a/monitord.conf
+++ b/monitord.conf
@@ -63,6 +63,14 @@ fedora39
 enabled = false
 num_slowest_units = 5
 
+# Optional: only include specific units in boot blame (if empty, all units are checked)
+[boot.allowlist]
+# slow-startup.service
+
+# Optional: exclude specific units from boot blame
+[boot.blocklist]
+# noisy-but-expected.service
+
 # Unit verification using systemd-analyze verify
 # Disabled by default as it can be slow on large systems
 [verify]

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -63,6 +63,18 @@ pub async fn update_boot_blame_stats(
         let unit_name = unit_info.0;
         let unit_path = unit_info.6;
 
+        // Apply blocklist: skip units explicitly excluded
+        if config.boot_blame.blocklist.contains(&unit_name) {
+            debug!("Skipping boot blame for {} due to blocklist", &unit_name);
+            continue;
+        }
+        // Apply allowlist: if non-empty, only include listed units
+        if !config.boot_blame.allowlist.is_empty()
+            && !config.boot_blame.allowlist.contains(&unit_name)
+        {
+            continue;
+        }
+
         match get_unit_activation_time(&connection, &unit_path).await {
             Ok(time) if time > 0.0 => {
                 unit_times.push((unit_name, time));


### PR DESCRIPTION
Allow filtering which units appear in boot blame results using the same allow/deny list pattern used by other modules (timers, machines, verify). Blocklist takes priority over allowlist when both are configured.