### PR TITLE
[monitord] Only discard D-Bus connections on transport-level errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,18 @@ pub mod verify;
 
 pub const DEFAULT_DBUS_ADDRESS: &str = "unix:path=/run/dbus/system_bus_socket";
 
+/// Check if an error indicates a broken D-Bus connection (I/O or handshake failure).
+/// Request-level errors (MethodError, FDO, etc.) do not indicate a broken connection.
+pub(crate) fn is_connection_error(err: &anyhow::Error) -> bool {
+    if let Some(zbus_err) = err.downcast_ref::<zbus::Error>() {
+        return matches!(
+            zbus_err,
+            zbus::Error::InputOutput(_) | zbus::Error::Handshake(_)
+        );
+    }
+    false
+}
+
 /// Stats collected for a single systemd-nspawn container or VM managed by systemd-machined
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct MachineStats {
@@ -259,12 +271,13 @@ pub async fn stat_collector(
                 Ok(r) => match r {
                     Ok(_) => (),
                     Err(e) => {
-                        had_error = true;
+                        if is_connection_error(&e) {
+                            had_error = true;
+                        }
                         error!("Collection specific failure: {:?}", e);
                     }
                 },
                 Err(e) => {
-                    had_error = true;
                     error!("Join error: {:?}", e);
                 }
             }

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -250,13 +250,15 @@ pub async fn update_machines_stats(
             ));
         }
 
-        let mut had_error = false;
+        let mut had_connection_error = false;
         while let Some(res) = join_set.join_next().await {
             match res {
                 Ok(r) => match r {
                     Ok(_) => (),
                     Err(e) => {
-                        had_error = true;
+                        if crate::is_connection_error(&e) {
+                            had_connection_error = true;
+                        }
                         error!(
                             "Collection specific failure (container {}): {:?}",
                             machine, e
@@ -264,13 +266,12 @@ pub async fn update_machines_stats(
                     }
                 },
                 Err(e) => {
-                    had_error = true;
                     error!("Join error (container {}): {:?}", machine, e);
                 }
             }
         }
 
-        if had_error {
+        if had_connection_error {
             evict_failed_connection(&cached_connections, &machine).await;
         }
 


### PR DESCRIPTION
Not all errors indicate a broken connection. Request-level errors (MethodError, FDO, etc.) leave the connection alive. Only evict cached connections and signal unusable host connection on I/O or handshake failures.