### PR TITLE
Support MONITORD_CONFIG env var for config path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming", "os::linux-apis"]
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.5", features = ["derive", "std", "help"], default-features = false }
+clap = { version = "4.5", features = ["derive", "std", "help", "env"], default-features = false }
 configparser = { version = "3.1.0", features = ["indexmap"] }
 futures-util = "0.3"
 indexmap = "2.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,13 @@ const LONG_ABOUT: &str = "monitord: Know how happy your systemd is! 😊";
 #[clap(author, version, about, long_about = LONG_ABOUT)]
 struct Cli {
     /// Location of your monitord config
-    #[clap(short, long, value_parser, env = "MONITORD_CONFIG", default_value = "/etc/monitord.conf")]
+    #[clap(
+        short,
+        long,
+        value_parser,
+        env = "MONITORD_CONFIG",
+        default_value = "/etc/monitord.conf"
+    )]
     config: PathBuf,
 
     /// Adjust the console log-level

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,13 +6,12 @@ use tracing::debug;
 use tracing::info;
 
 const LONG_ABOUT: &str = "monitord: Know how happy your systemd is! 😊";
-
 /// Clap CLI Args struct with metadata in help output
 #[derive(Debug, Parser)]
 #[clap(author, version, about, long_about = LONG_ABOUT)]
 struct Cli {
     /// Location of your monitord config
-    #[clap(short, long, value_parser, default_value = "/etc/monitord.conf")]
+    #[clap(short, long, value_parser, env = "MONITORD_CONFIG", default_value = "/etc/monitord.conf")]
     config: PathBuf,
 
     /// Adjust the console log-level


### PR DESCRIPTION
Allow setting the config file path via the MONITORD_CONFIG environment variable as a fallback between the -c CLI flag and the default /etc/monitord.conf. Uses clap's built-in env feature for proper precedence handling and --help display.