### PR TITLE
Make ServiceStats fields nullable to avoid zero-filled output (#183)

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -647,22 +647,7 @@ mod tests {
   "pid1.fd_count": 69,
   "pid1.memory_usage_bytes": 69,
   "pid1.tasks": 1,
-  "services.unittest.service.active_enter_timestamp": 0,
-  "services.unittest.service.active_exit_timestamp": 0,
-  "services.unittest.service.cpuusage_nsec": 0,
-  "services.unittest.service.inactive_exit_timestamp": 0,
-  "services.unittest.service.ioread_bytes": 0,
-  "services.unittest.service.ioread_operations": 0,
-  "services.unittest.service.memory_available": 0,
-  "services.unittest.service.memory_current": 0,
-  "services.unittest.service.nrestarts": 0,
-  "services.unittest.service.processes": 0,
-  "services.unittest.service.restart_usec": 0,
-  "services.unittest.service.state_change_timestamp": 0,
   "services.unittest.service.status_errno": -69,
-  "services.unittest.service.tasks_current": 0,
-  "services.unittest.service.timeout_clean_usec": 0,
-  "services.unittest.service.watchdog_usec": 0,
   "stat_collection_run_time_ms": 69.0,
   "system-state": 3,
   "timers.unittest.timer.accuracy_usec": 69,
@@ -773,7 +758,7 @@ mod tests {
             service_unit_name.clone(),
             units::ServiceStats {
                 // Ensure json-flat handles negative i32s
-                status_errno: -69,
+                status_errno: Some(-69),
                 ..Default::default()
             },
         );
@@ -835,7 +820,7 @@ mod tests {
     #[test]
     fn test_flatten_map() {
         let json_flat_map = flatten_stats(&return_monitord_stats(), "");
-        assert_eq!(127, json_flat_map.len());
+        assert_eq!(112, json_flat_map.len());
     }
 
     #[test]

--- a/src/units.rs
+++ b/src/units.rs
@@ -117,42 +117,62 @@ pub struct SystemdUnitStats {
 
 /// Per-service metrics from the org.freedesktop.systemd1.Service and Unit D-Bus interfaces.
 /// Ref: <https://www.freedesktop.org/software/systemd/man/org.freedesktop.systemd1.html>
+///
+/// Fields are `Option` so that collection paths that only populate a subset
+/// (e.g. varlink only provides `nrestarts`) do not emit zero-valued keys for
+/// the fields they never fetched.
 #[derive(
     serde::Serialize, serde::Deserialize, Clone, Debug, Default, Eq, FieldNamesAsArray, PartialEq,
 )]
 pub struct ServiceStats {
     /// Realtime timestamp (usec since epoch) when the unit most recently entered the active state
-    pub active_enter_timestamp: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_enter_timestamp: Option<u64>,
     /// Realtime timestamp (usec since epoch) when the unit most recently left the active state
-    pub active_exit_timestamp: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_exit_timestamp: Option<u64>,
     /// Total CPU time consumed by this service's cgroup in nanoseconds
-    pub cpuusage_nsec: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpuusage_nsec: Option<u64>,
     /// Realtime timestamp (usec since epoch) when the unit most recently left the inactive state
-    pub inactive_exit_timestamp: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inactive_exit_timestamp: Option<u64>,
     /// Total bytes read from block I/O by this service's cgroup
-    pub ioread_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ioread_bytes: Option<u64>,
     /// Total number of block I/O read operations by this service's cgroup
-    pub ioread_operations: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ioread_operations: Option<u64>,
     /// Memory available to the service (MemoryAvailable from cgroup), in bytes
-    pub memory_available: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_available: Option<u64>,
     /// Current memory usage of the service's cgroup in bytes
-    pub memory_current: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_current: Option<u64>,
     /// Number of times systemd has restarted this service (automatic restarts)
-    pub nrestarts: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nrestarts: Option<u32>,
     /// Current number of processes in this service's cgroup
-    pub processes: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub processes: Option<u32>,
     /// Configured restart delay for this service in microseconds (RestartUSec)
-    pub restart_usec: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub restart_usec: Option<u64>,
     /// Realtime timestamp (usec since epoch) of the most recent state change of any kind
-    pub state_change_timestamp: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_change_timestamp: Option<u64>,
     /// errno-style exit status code from the main process (0 = success)
-    pub status_errno: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_errno: Option<i32>,
     /// Current number of tasks (threads) in this service's cgroup
-    pub tasks_current: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tasks_current: Option<u64>,
     /// Timeout in microseconds for the cleanup of resources after the service exits
-    pub timeout_clean_usec: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_clean_usec: Option<u64>,
     /// Watchdog timeout in microseconds; the service must ping within this interval or be killed
-    pub watchdog_usec: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watchdog_usec: Option<u64>,
 }
 
 /// Per-unit state tracking combining active state, load state, and computed health.
@@ -295,22 +315,22 @@ async fn parse_service(
     );
 
     Ok(ServiceStats {
-        active_enter_timestamp: active_enter_timestamp?,
-        active_exit_timestamp: active_exit_timestamp?,
-        cpuusage_nsec: cpuusage_nsec?,
-        inactive_exit_timestamp: inactive_exit_timestamp?,
-        ioread_bytes: ioread_bytes?,
-        ioread_operations: ioread_operations?,
-        memory_current: memory_current?,
-        memory_available: memory_available?,
-        nrestarts: nrestarts?,
-        processes: processes?.len().try_into()?,
-        restart_usec: restart_usec?,
-        state_change_timestamp: state_change_timestamp?,
-        status_errno: status_errno?,
-        tasks_current: tasks_current?,
-        timeout_clean_usec: timeout_clean_usec?,
-        watchdog_usec: watchdog_usec?,
+        active_enter_timestamp: Some(active_enter_timestamp?),
+        active_exit_timestamp: Some(active_exit_timestamp?),
+        cpuusage_nsec: Some(cpuusage_nsec?),
+        inactive_exit_timestamp: Some(inactive_exit_timestamp?),
+        ioread_bytes: Some(ioread_bytes?),
+        ioread_operations: Some(ioread_operations?),
+        memory_current: Some(memory_current?),
+        memory_available: Some(memory_available?),
+        nrestarts: Some(nrestarts?),
+        processes: Some(processes?.len().try_into()?),
+        restart_usec: Some(restart_usec?),
+        state_change_timestamp: Some(state_change_timestamp?),
+        status_errno: Some(status_errno?),
+        tasks_current: Some(tasks_current?),
+        timeout_clean_usec: Some(timeout_clean_usec?),
+        watchdog_usec: Some(watchdog_usec?),
     })
 }
 

--- a/src/varlink_units.rs
+++ b/src/varlink_units.rs
@@ -141,7 +141,7 @@ pub fn parse_one_metric(
                 .service_stats
                 .entry(object_name.to_string())
                 .or_default()
-                .nrestarts = nrestarts;
+                .nrestarts = Some(nrestarts);
         }
         "UnitsByTypeTotal" => {
             if let Some(type_str) = metric.get_field_as_str("type") {
@@ -413,7 +413,7 @@ mod tests {
                 .get("my-service.service")
                 .unwrap()
                 .nrestarts,
-            5
+            Some(5)
         );
     }
 


### PR DESCRIPTION
The varlink path creates ServiceStats entries for every service unit via NRestarts metrics, but only populates nrestarts — the remaining 15 fields were emitted as zeros. On a system with ~390 services this produced ~6,270 useless  and false JSON keys.

Making all ServiceStats fields Option<T> with skip_serializing_if means only fields with actual data are emitted. The D-Bus path wraps all values in Some(), so its output is unchanged. The varlink path now emits only nrestarts per service instead of 16 fields.


now we only produce 3224 metrics but they all are true