### PR TITLE
Add unit_files stats for generated and transient unit file counts

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -114,6 +114,39 @@ fn flatten_pid1(
     ]
 }
 
+fn flatten_unit_files_scope(
+    scope: &units::UnitFilesScope,
+    base: &str,
+) -> Vec<(String, serde_json::Value)> {
+    let mut flat_stats = Vec::new();
+    for (unit_type, count) in &scope.generated {
+        flat_stats.push((
+            format!("{base}.generated.{unit_type}_units"),
+            (*count).into(),
+        ));
+    }
+    for (unit_type, count) in &scope.transient {
+        flat_stats.push((
+            format!("{base}.transient.{unit_type}_units"),
+            (*count).into(),
+        ));
+    }
+    flat_stats
+}
+
+fn flatten_unit_files(
+    unit_files: &units::UnitFilesStats,
+    key_prefix: &str,
+) -> Vec<(String, serde_json::Value)> {
+    let base = gen_base_metric_key(key_prefix, "unit_files");
+    let mut flat_stats = flatten_unit_files_scope(&unit_files.root, &format!("{base}.root"));
+    flat_stats.extend(flatten_unit_files_scope(
+        &unit_files.user,
+        &format!("{base}.user"),
+    ));
+    flat_stats
+}
+
 fn flatten_services(
     service_stats_hash: &HashMap<String, units::ServiceStats>,
     key_prefix: &str,
@@ -272,6 +305,10 @@ fn flatten_machines(
         };
         flat_stats.extend(flatten_networkd(&stats.networkd, &machine_key_prefix));
         flat_stats.extend(flatten_units(&stats.units, &machine_key_prefix));
+        flat_stats.extend(flatten_unit_files(
+            &stats.units.unit_files,
+            &machine_key_prefix,
+        ));
         flat_stats.extend(flatten_units_collection_timings(
             &stats.units.collection_timings,
             &machine_key_prefix,
@@ -554,6 +591,10 @@ fn flatten_stats(
         key_prefix,
     ));
     flat_stats.extend(flatten_units(&stats_struct.units, key_prefix));
+    flat_stats.extend(flatten_unit_files(
+        &stats_struct.units.unit_files,
+        key_prefix,
+    ));
     flat_stats.insert(
         gen_base_metric_key(key_prefix, "version"),
         stats_struct.version.to_string().into(),
@@ -864,6 +905,7 @@ mod tests {
     fn test_unit_counters_covers_all_scalar_fields() {
         // Fields of SystemdUnitStats that are nested maps, not scalar counters.
         const NON_COUNTER_FIELDS: &[&str] = &[
+            "unit_files",
             "service_stats",
             "timer_stats",
             "unit_states",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,9 @@ pub async fn stat_collector(
                     .await
                     {
                         Ok(()) => {
+                            let unit_files_handle = tokio::task::spawn_blocking(|| {
+                                crate::units::collect_unit_files_stats("")
+                            });
                             // Timer properties are not yet exposed via varlink; collect via D-Bus.
                             match crate::timer::collect_all_timers_dbus(&sdc_clone, &config_clone)
                                 .await
@@ -305,6 +308,10 @@ pub async fn stat_collector(
                                     warn!("Varlink timer stats (D-Bus fallback) failed: {:?}", err);
                                 }
                             }
+                            if let Ok(unit_files) = unit_files_handle.await {
+                                let mut ms = stats_clone.write().await;
+                                ms.units.unit_files = unit_files;
+                            }
                             return Ok(());
                         }
                         Err(err) => {
@@ -315,7 +322,8 @@ pub async fn stat_collector(
                         }
                     }
                 }
-                crate::units::update_unit_stats(config_clone, sdc_clone, stats_clone).await
+                crate::units::update_unit_stats(config_clone, sdc_clone, stats_clone, String::new())
+                    .await
             });
         }
 

--- a/src/machines.rs
+++ b/src/machines.rs
@@ -249,22 +249,41 @@ pub async fn update_machines_stats(
                     )
                     .await
                     {
-                        Ok(()) => Ok(()),
+                        Ok(()) => {
+                            let container_root = format!("/proc/{}/root", leader_pid);
+                            let unit_files = tokio::task::spawn_blocking(move || {
+                                crate::units::collect_unit_files_stats(&container_root)
+                            })
+                            .await;
+                            if let Ok(unit_files) = unit_files {
+                                let mut ms = stats_clone.write().await;
+                                ms.units.unit_files = unit_files;
+                            }
+                            Ok(())
+                        }
                         Err(err) => {
                             warn!(
                                 "Varlink units stats failed, falling back to D-Bus: {:?}",
                                 err
                             );
-                            crate::units::update_unit_stats(config_clone, sdc_clone, stats_clone)
-                                .await
+                            let container_root = format!("/proc/{}/root", leader_pid);
+                            crate::units::update_unit_stats(
+                                config_clone,
+                                sdc_clone,
+                                stats_clone,
+                                container_root,
+                            )
+                            .await
                         }
                     }
                 });
             } else {
+                let container_root = format!("/proc/{}/root", leader_pid);
                 join_set.spawn(crate::units::update_unit_stats(
                     Arc::clone(&config),
                     sdc.clone(),
                     locked_machine_stats.clone(),
+                    container_root,
                 ));
             }
         }

--- a/src/units.rs
+++ b/src/units.rs
@@ -55,6 +55,22 @@ pub struct UnitsCollectionTimings {
     pub service_dbus_fetches: u64,
 }
 
+/// Unit file counts for a scope (root or user), broken down by unit type.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct UnitFilesScope {
+    /// Generated unit files by type (e.g. "service" => 2, "mount" => 5)
+    pub generated: HashMap<String, u64>,
+    /// Transient unit files by type (e.g. "service" => 10, "scope" => 6)
+    pub transient: HashMap<String, u64>,
+}
+
+/// Unit file statistics collected from the filesystem for root and user scopes.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct UnitFilesStats {
+    pub root: UnitFilesScope,
+    pub user: UnitFilesScope,
+}
+
 #[derive(
     serde::Serialize, serde::Deserialize, Clone, Debug, Default, FieldNamesAsArray, PartialEq,
 )]
@@ -104,6 +120,8 @@ pub struct SystemdUnitStats {
     pub timer_remain_after_elapse: u64,
     /// Total number of units known to systemd (all types, all states)
     pub total_units: u64,
+    /// Unit file statistics from the filesystem (e.g. generator output counts)
+    pub unit_files: UnitFilesStats,
     /// Per-service detailed metrics keyed by unit name (e.g. "sshd.service")
     pub service_stats: HashMap<String, ServiceStats>,
     /// Per-timer detailed metrics keyed by unit name (e.g. "logrotate.timer")
@@ -429,10 +447,80 @@ fn parse_unit(stats: &mut SystemdUnitStats, unit: &ListedUnit) {
     }
 }
 
+const GENERATOR_DIRS: &[&str] = &[
+    "/run/systemd/generator",
+    "/run/systemd/generator.early",
+    "/run/systemd/generator.late",
+];
+const TRANSIENT_DIR: &str = "/run/systemd/transient";
+
+fn count_unit_files_by_type(path: &str) -> HashMap<String, u64> {
+    let dir = match std::fs::read_dir(path) {
+        Ok(d) => d,
+        Err(err) => {
+            debug!("Unable to read {}: {:?}", path, err);
+            return HashMap::new();
+        }
+    };
+    let mut counts = HashMap::new();
+    for entry in dir.filter_map(|e| e.ok()) {
+        if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let name = entry.file_name();
+        let unit_type = name
+            .to_str()
+            .and_then(|n| n.rsplit('.').next())
+            .unwrap_or("unknown");
+        *counts.entry(unit_type.to_string()).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn merge_counts(target: &mut HashMap<String, u64>, source: HashMap<String, u64>) {
+    for (unit_type, count) in source {
+        *target.entry(unit_type).or_insert(0) += count;
+    }
+}
+
+/// Collect unit file statistics from the filesystem.
+/// `fs_root` is prepended to all paths — empty string for the host,
+/// `/proc/<pid>/root` for containers.
+pub fn collect_unit_files_stats(fs_root: &str) -> UnitFilesStats {
+    let mut root_generated = HashMap::new();
+    for dir in GENERATOR_DIRS {
+        merge_counts(
+            &mut root_generated,
+            count_unit_files_by_type(&format!("{fs_root}{dir}")),
+        );
+    }
+
+    let mut user_transient = HashMap::new();
+    let user_dir = format!("{fs_root}/run/user");
+    if let Ok(entries) = std::fs::read_dir(&user_dir) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = format!("{}/systemd/transient", entry.path().display());
+            merge_counts(&mut user_transient, count_unit_files_by_type(&path));
+        }
+    }
+
+    UnitFilesStats {
+        root: UnitFilesScope {
+            generated: root_generated,
+            transient: count_unit_files_by_type(&format!("{fs_root}{TRANSIENT_DIR}")),
+        },
+        user: UnitFilesScope {
+            generated: HashMap::new(),
+            transient: user_transient,
+        },
+    }
+}
+
 /// Pull all units from dbus and count how system is setup and behaving
 pub async fn parse_unit_state(
     config: &crate::config::Config,
     connection: &zbus::Connection,
+    fs_root: &str,
 ) -> Result<SystemdUnitStats, MonitordUnitsError> {
     if !config.units.state_stats_allowlist.is_empty() {
         debug!(
@@ -449,6 +537,11 @@ pub async fn parse_unit_state(
     }
 
     let mut stats = SystemdUnitStats::default();
+
+    let fs_root_owned = fs_root.to_string();
+    let unit_files_handle =
+        tokio::task::spawn_blocking(move || collect_unit_files_stats(&fs_root_owned));
+
     let p = crate::dbus::zbus_systemd::ManagerProxy::builder(connection)
         .cache_properties(zbus::proxy::CacheProperties::No)
         .build()
@@ -528,18 +621,26 @@ pub async fn parse_unit_state(
     stats.collection_timings.service_dbus_fetches = service_dbus_fetches;
     stats.collection_timings.timer_dbus_fetches = timer_dbus_fetches;
 
+    match unit_files_handle.await {
+        Ok(unit_files) => stats.unit_files = unit_files,
+        Err(err) => error!("Failed to collect unit file stats: {:?}", err),
+    }
+
     debug!("unit stats: {:?}", stats);
     Ok(stats)
 }
 
-/// Async wrapper than can update uni stats when passed a locked struct
+/// Async wrapper that can update unit stats when passed a locked struct.
+/// `fs_root` is prepended to filesystem paths for unit file stats —
+/// empty string for the host, `/proc/<pid>/root` for containers.
 pub async fn update_unit_stats(
     config: Arc<crate::config::Config>,
     connection: zbus::Connection,
     locked_machine_stats: Arc<RwLock<MachineStats>>,
+    fs_root: String,
 ) -> anyhow::Result<()> {
     let mut machine_stats = locked_machine_stats.write().await;
-    match parse_unit_state(&config, &connection).await {
+    match parse_unit_state(&config, &connection, &fs_root).await {
         Ok(units_stats) => machine_stats.units = units_stats,
         Err(err) => error!("units stats failed: {:?}", err),
     }
@@ -598,6 +699,7 @@ mod tests {
             timer_persistent_units: 0,
             timer_remain_after_elapse: 0,
             total_units: 0,
+            unit_files: UnitFilesStats::default(),
             service_stats: HashMap::new(),
             timer_stats: HashMap::new(),
             unit_states: HashMap::from([(
@@ -667,6 +769,7 @@ mod tests {
             timer_persistent_units: 0,
             timer_remain_after_elapse: 0,
             total_units: 0,
+            unit_files: UnitFilesStats::default(),
             service_stats: HashMap::new(),
             timer_stats: HashMap::new(),
             unit_states: HashMap::new(),
@@ -693,5 +796,57 @@ mod tests {
     fn test_iterators() {
         assert!(SystemdUnitActiveState::iter().collect::<Vec<_>>().len() > 0);
         assert!(SystemdUnitLoadState::iter().collect::<Vec<_>>().len() > 0);
+    }
+
+    #[test]
+    fn test_count_unit_files_by_type() {
+        let dir = tempfile::tempdir().expect("Unable to create temp dir");
+        let path = dir.path();
+
+        std::fs::write(path.join("sshd.service"), "").unwrap();
+        std::fs::write(path.join("nginx.service"), "").unwrap();
+        std::fs::write(path.join("boot.mount"), "").unwrap();
+        std::fs::write(path.join("swap.swap"), "").unwrap();
+        std::fs::create_dir(path.join("multi-user.target.wants")).unwrap();
+
+        let counts = count_unit_files_by_type(path.to_str().unwrap());
+        assert_eq!(counts.get("service"), Some(&2));
+        assert_eq!(counts.get("mount"), Some(&1));
+        assert_eq!(counts.get("swap"), Some(&1));
+        assert_eq!(counts.get("wants"), None);
+        assert_eq!(counts.len(), 3);
+    }
+
+    #[test]
+    fn test_count_unit_files_by_type_nonexistent_dir() {
+        let counts = count_unit_files_by_type("/nonexistent/path");
+        assert!(counts.is_empty());
+    }
+
+    #[test]
+    fn test_collect_unit_files_stats_with_fs_root() {
+        let root = tempfile::tempdir().expect("Unable to create temp dir");
+        let root_path = root.path();
+
+        let gen_dir = root_path.join("run/systemd/generator");
+        std::fs::create_dir_all(&gen_dir).unwrap();
+        std::fs::write(gen_dir.join("boot.mount"), "").unwrap();
+        std::fs::write(gen_dir.join("swap.swap"), "").unwrap();
+
+        let transient_dir = root_path.join("run/systemd/transient");
+        std::fs::create_dir_all(&transient_dir).unwrap();
+        std::fs::write(transient_dir.join("run-thing.service"), "").unwrap();
+
+        let user_transient = root_path.join("run/user/1000/systemd/transient");
+        std::fs::create_dir_all(&user_transient).unwrap();
+        std::fs::write(user_transient.join("app-code.scope"), "").unwrap();
+        std::fs::write(user_transient.join("app-term.scope"), "").unwrap();
+
+        let stats = collect_unit_files_stats(root_path.to_str().unwrap());
+        assert_eq!(stats.root.generated.get("mount"), Some(&1));
+        assert_eq!(stats.root.generated.get("swap"), Some(&1));
+        assert_eq!(stats.root.transient.get("service"), Some(&1));
+        assert_eq!(stats.user.transient.get("scope"), Some(&2));
+        assert!(stats.user.generated.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Add `UnitFilesStats` and `UnitFilesScope` structs to track unit file counts by scope (root/user) and unit type
- Count generated unit files from `/run/systemd/generator{,.early,.late}` and transient unit files from `/run/systemd/transient` and `/run/user/*/systemd/transient/`
- Filesystem-based counting — no D-Bus `ListUnitFiles` or varlink overhead
- Container-aware via `fs_root` parameter (`/proc/<pid>/root/...` prefix)
- Consistent across D-Bus and varlink collection paths

### Metric keys
```
monitord.unit_files.root.generated.<type>_units
monitord.unit_files.root.transient.<type>_units
monitord.unit_files.user.transient.<type>_units
```

Where `<type>` is the unit file extension (service, mount, swap, socket, scope, etc.)

## Test plan
- [x] `cargo test --lib` — 107 tests pass
- [x] New tests for `count_unit_files_by_type` (files only, not dirs), nonexistent dir (returns empty), and end-to-end `collect_unit_files_stats` with temp dir
- [x] Verified output with `cargo run -- -c monitord.conf` shows correct counts