### PR TITLE
Add configurable cache_dir for boot blame cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ enabled = false
 # Cache boot blame stats in <cache_dir>/<boot_id>.boot_blame.bin
 # Enabled by default; set false to force recalculation every run
 cache_enabled = true
-# Directory where boot blame cache files are stored
-# Defaults to /run/monitord if not set
-cache_dir = /tmp
+# Directory where boot blame cache files are stored (optional)
+# Defaults to /run/monitord if not set; avoid world-writable dirs like /tmp when running privileged
+# cache_dir = /tmp
 # Number of slowest units to report
 num_slowest_units = 5
 

--- a/README.md
+++ b/README.md
@@ -218,9 +218,12 @@ bar
 # Disabled by default
 [boot]
 enabled = false
-# Cache boot blame stats in /run/monitord/<boot_id>.boot_blame.bin
+# Cache boot blame stats in <cache_dir>/<boot_id>.boot_blame.bin
 # Enabled by default; set false to force recalculation every run
 cache_enabled = true
+# Directory where boot blame cache files are stored
+# Defaults to /run/monitord if not set
+cache_dir = /tmp
 # Number of slowest units to report
 num_slowest_units = 5
 
@@ -251,8 +254,9 @@ enabled = false
 
 When using the provided `monitord.service`, systemd creates `/run/monitord` via
 `RuntimeDirectory=monitord` and assigns ownership to the configured service `User`/`Group`.
-If you run monitord another way, ensure `/run/monitord` exists and is writable by the
-monitord process user so boot cache files can be created.
+If you run monitord another way and use the default `cache_dir` (`/run/monitord`), ensure the
+directory exists and is writable by the monitord process user so boot cache files can be created.
+Alternatively, set `cache_dir` to a location like `/tmp` that is always writable.
 
 ## Machines support
 

--- a/monitord.conf
+++ b/monitord.conf
@@ -68,9 +68,12 @@ fedora39
 # Shows the N slowest units at boot (similar to systemd-analyze blame)
 [boot]
 enabled = false
-# Cache boot blame stats in /run/monitord/<boot_id>.boot_blame.bin
+# Cache boot blame stats in <cache_dir>/<boot_id>.boot_blame.bin
 # Enabled by default; set false to force recalculation every run
 cache_enabled = true
+# Directory where boot blame cache files are stored
+# Defaults to /run/monitord if not set
+cache_dir = /tmp
 num_slowest_units = 5
 
 # Optional: only include specific units in boot blame (if empty, all units are checked)

--- a/src/boot.rs
+++ b/src/boot.rs
@@ -24,7 +24,6 @@ use crate::MachineStats;
 pub type BootBlameStats = HashMap<String, f64>;
 
 const BOOT_ID_PATH: &str = "/proc/sys/kernel/random/boot_id";
-const BOOT_BLAME_CACHE_DIR: &str = "/run/monitord";
 const BOOT_BLAME_CACHE_SUFFIX: &str = "boot_blame.bin";
 
 type BootCacheResult<T> = std::result::Result<T, BootCacheError>;
@@ -139,14 +138,6 @@ async fn write_cached_boot_blame_to_dir(
     Ok(())
 }
 
-async fn read_cached_boot_blame(boot_id: &str) -> BootCacheResult<Option<BootBlameStats>> {
-    read_cached_boot_blame_from_dir(Path::new(BOOT_BLAME_CACHE_DIR), boot_id).await
-}
-
-async fn write_cached_boot_blame(boot_id: &str, stats: &BootBlameStats) -> BootCacheResult<()> {
-    write_cached_boot_blame_to_dir(Path::new(BOOT_BLAME_CACHE_DIR), boot_id, stats).await
-}
-
 /// Calculate the activation time for a unit
 /// Returns the time in seconds from InactiveExitTimestamp to ActiveEnterTimestamp
 async fn get_unit_activation_time(
@@ -190,11 +181,12 @@ pub async fn update_boot_blame_stats(
             return Ok(());
         }
 
+        let cache_dir = Path::new(&config.boot_blame.cache_dir);
         match get_boot_id().await {
             Ok(boot_id) => {
-                match read_cached_boot_blame(&boot_id).await {
+                match read_cached_boot_blame_from_dir(cache_dir, &boot_id).await {
                     Ok(Some(cached_boot_blame)) => {
-                        let cache_path = cache_file_path(Path::new(BOOT_BLAME_CACHE_DIR), &boot_id);
+                        let cache_path = cache_file_path(cache_dir, &boot_id);
                         debug!(
                             "Using cached boot blame stats from {}",
                             cache_path.display()
@@ -276,10 +268,13 @@ pub async fn update_boot_blame_stats(
     if config.boot_blame.cache_enabled {
         if let Some(boot_id) = maybe_boot_id {
             if let Some(cached_stats) = stats.boot_blame.as_ref() {
-                if let Err(err) = write_cached_boot_blame(&boot_id, cached_stats).await {
+                let cache_dir = Path::new(&config.boot_blame.cache_dir);
+                if let Err(err) =
+                    write_cached_boot_blame_to_dir(cache_dir, &boot_id, cached_stats).await
+                {
                     debug!(
                         "Failed to write boot blame cache for boot id {} to {}: {}",
-                        boot_id, BOOT_BLAME_CACHE_DIR, err
+                        boot_id, config.boot_blame.cache_dir, err
                     );
                 } else {
                     debug!("Updated boot blame cache for boot id {}", boot_id);

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,6 +193,7 @@ impl Default for DBusStatsConfig {
 pub struct BootBlameConfig {
     pub enabled: bool,
     pub cache_enabled: bool,
+    pub cache_dir: String,
     pub num_slowest_units: u64,
     pub allowlist: HashSet<String>,
     pub blocklist: HashSet<String>,
@@ -202,6 +203,7 @@ impl Default for BootBlameConfig {
         BootBlameConfig {
             enabled: false,
             cache_enabled: true,
+            cache_dir: "/run/monitord".to_string(),
             num_slowest_units: 5,
             allowlist: HashSet::new(),
             blocklist: HashSet::new(),
@@ -373,6 +375,9 @@ impl TryFrom<Ini> for Config {
         {
             config.boot_blame.cache_enabled = cache_enabled;
         }
+        if let Some(cache_dir) = ini_config.get("boot", "cache_dir") {
+            config.boot_blame.cache_dir = cache_dir;
+        }
         if let Ok(Some(num_slowest_units)) = ini_config.getuint("boot", "num_slowest_units") {
             config.boot_blame.num_slowest_units = num_slowest_units;
         }
@@ -529,6 +534,7 @@ foo2
 [boot]
 enabled = true
 cache_enabled = false
+cache_dir = /tmp/monitord-test
 num_slowest_units = 10
 
 [boot.allowlist]
@@ -627,6 +633,7 @@ output_format = json-flat
             boot_blame: BootBlameConfig {
                 enabled: true,
                 cache_enabled: false,
+                cache_dir: "/tmp/monitord-test".to_string(),
                 num_slowest_units: 10,
                 allowlist: HashSet::from([String::from("foo.service")]),
                 blocklist: HashSet::from([String::from("bar.service")]),


### PR DESCRIPTION
## Summary

Add a new `cache_dir` option to the `[boot]` config section, allowing users to specify where boot blame cache files (`<boot_id>.boot_blame.bin`) are stored.

Previously the cache directory was hardcoded to `/run/monitord`, which requires systemd's `RuntimeDirectory` or manual directory creation. With this change, users can set `cache_dir` to any writable location (e.g. `/tmp`) for easier standalone usage.

The default remains `/run/monitord` for backward compatibility.

## Changes

- **`src/config.rs`**: Add `cache_dir: String` field to `BootBlameConfig` (default: `/run/monitord`); parse from `[boot]` INI section
- **`src/boot.rs`**: Remove hardcoded `BOOT_BLAME_CACHE_DIR` constant and unused wrapper functions (`read_cached_boot_blame`, `write_cached_boot_blame`); use `config.boot_blame.cache_dir` directly
- **`monitord.conf`**: Add `cache_dir = /tmp` with documentation
- **`README.md`**: Document the new option and update setup instructions

## Example config

```ini
[boot]
enabled = true
cache_enabled = true
cache_dir = /tmp
num_slowest_units = 5
```

## Testing

All 107 library tests pass including updated config parsing tests with the new `cache_dir` field.