### PR TITLE
Bound per-unit D-Bus concurrency in the units collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ plus an inner phase breakdown for the units collector
 | `collection_timings.timer_dbus_fetches` | Count of timer D-Bus property fetches this run. |
 | `collection_timings.state_dbus_fetches` | Count of unit-state D-Bus fetches (only when `state_stats_time_in_state` is enabled). |
 | `collection_timings.service_dbus_fetches` | Count of per-service D-Bus property fetches. |
+| `collection_timings.slowest_units` | The `units.slowest_units_count` slowest units this run (unit name, duration ms), descending. Empty when `slowest_units_count = 0`. D-Bus path only (see parity note below). |
 
 Comparing `sum(collector_timings.*.elapsed_ms)` against
 `stat_collection_run_time_ms` gives an effective parallelism ratio

--- a/monitord.conf
+++ b/monitord.conf
@@ -48,6 +48,11 @@ state_stats = true
 state_stats_time_in_state = true
 ignore_inactive_oneshot_services = true
 unit_files = true
+# Max units whose D-Bus work runs concurrently in the per-unit collection loop
+per_unit_concurrency = 8
+# Number of slowest units (by per-unit collection duration) to record;
+# 0 disables
+slowest_units_count = 5
 
 [units.state_stats.allowlist]
 # Remove 'd' so it works when I test on ubuntu

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,6 +122,14 @@ pub struct UnitsConfig {
     pub state_stats_time_in_state: bool,
     pub ignore_inactive_oneshot_services: bool,
     pub unit_files: bool,
+    /// Max number of units whose D-Bus work runs concurrently in the per-unit
+    /// collection loop. Bounded (rather than unbounded) so a burst of
+    /// simultaneous D-Bus calls doesn't itself worsen host-level IPC
+    /// contention on hosts where per-call latency is already elevated.
+    pub per_unit_concurrency: u64,
+    /// Number of slowest units (by per-unit collection duration) to record in
+    /// `UnitsCollectionTimings::slowest_units`. Set to 0 to disable.
+    pub slowest_units_count: u64,
 }
 impl Default for UnitsConfig {
     fn default() -> Self {
@@ -133,6 +141,8 @@ impl Default for UnitsConfig {
             state_stats_time_in_state: true,
             ignore_inactive_oneshot_services: true,
             unit_files: true,
+            per_unit_concurrency: 8,
+            slowest_units_count: 5,
         }
     }
 }
@@ -332,6 +342,13 @@ impl TryFrom<Ini> for Config {
         if let Some(unit_files) = read_config_optional_bool(&ini_config, "units", "unit_files")? {
             config.units.unit_files = unit_files;
         }
+        if let Ok(Some(per_unit_concurrency)) = ini_config.getuint("units", "per_unit_concurrency")
+        {
+            config.units.per_unit_concurrency = per_unit_concurrency;
+        }
+        if let Ok(Some(slowest_units_count)) = ini_config.getuint("units", "slowest_units_count") {
+            config.units.slowest_units_count = slowest_units_count;
+        }
 
         // [machines] section
         config.machines.enabled = read_config_bool(&ini_config, "machines", "enabled")?;
@@ -501,6 +518,8 @@ state_stats = true
 state_stats_time_in_state = true
 ignore_inactive_oneshot_services = true
 unit_files = true
+per_unit_concurrency = 16
+slowest_units_count = 3
 
 [units.state_stats.allowlist]
 foo.service
@@ -623,6 +642,31 @@ ignore_inactive_oneshot_services = false
     }
 
     #[test]
+    fn test_units_per_unit_concurrency_override() {
+        let units_override_config = r###"
+[monitord]
+output_format = json
+
+[units]
+per_unit_concurrency = 32
+slowest_units_count = 0
+"###;
+        let mut monitord_config = NamedTempFile::new().expect("Unable to make named tempfile");
+        monitord_config
+            .write_all(units_override_config.as_bytes())
+            .expect("Unable to write out temp config file");
+
+        let mut ini_config = Ini::new();
+        let _config_map = ini_config
+            .load(monitord_config.path())
+            .expect("Unable to load ini config");
+
+        let parsed_config: Config = ini_config.try_into().expect("Failed to parse config");
+        assert_eq!(parsed_config.units.per_unit_concurrency, 32);
+        assert_eq!(parsed_config.units.slowest_units_count, 0);
+    }
+
+    #[test]
     fn test_full_config() {
         let expected_config = Config {
             monitord: MonitordConfig {
@@ -653,6 +697,8 @@ ignore_inactive_oneshot_services = false
                 state_stats_time_in_state: true,
                 ignore_inactive_oneshot_services: true,
                 unit_files: true,
+                per_unit_concurrency: 16,
+                slowest_units_count: 3,
             },
             machines: MachinesConfig {
                 enabled: true,

--- a/src/json.rs
+++ b/src/json.rs
@@ -562,6 +562,14 @@ fn flatten_units_collection_timings(
         format!("{base_metric_name}.service_dbus_fetches"),
         timings.service_dbus_fetches.into(),
     );
+    // Rank is encoded in the key (not just the unit name) so ordering survives
+    // flattening; the leaf value stays a plain number like every other key here.
+    for (idx, (unit_name, duration_ms)) in timings.slowest_units.iter().enumerate() {
+        flat_stats.insert(
+            format!("{base_metric_name}.slowest_units.{idx}.{unit_name}"),
+            (*duration_ms).into(),
+        );
+    }
     flat_stats
 }
 
@@ -636,6 +644,8 @@ mod tests {
   "collection_timings.list_units_ms": 5.0,
   "collection_timings.per_unit_loop_ms": 37.0,
   "collection_timings.service_dbus_fetches": 1,
+  "collection_timings.slowest_units.0.unittest.service": 12.5,
+  "collection_timings.slowest_units.1.unittest.timer": 8.25,
   "collection_timings.state_dbus_fetches": 0,
   "collection_timings.timer_dbus_fetches": 4,
   "collector_timings.boot_blame.elapsed_ms": 12.5,
@@ -817,6 +827,10 @@ mod tests {
             timer_dbus_fetches: 4,
             state_dbus_fetches: 0,
             service_dbus_fetches: 1,
+            slowest_units: vec![
+                ("unittest.service".to_string(), 12.5),
+                ("unittest.timer".to_string(), 8.25),
+            ],
         };
         let service_unit_name = String::from("unittest.service");
         stats.units.service_stats.insert(
@@ -885,7 +899,7 @@ mod tests {
     #[test]
     fn test_flatten_map() {
         let json_flat_map = flatten_stats(&return_monitord_stats(), "");
-        assert_eq!(127, json_flat_map.len());
+        assert_eq!(129, json_flat_map.len());
     }
 
     #[test]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -7,8 +7,6 @@ use struct_field_names_as_array::FieldNamesAsArray;
 use thiserror::Error;
 use tracing::error;
 
-use crate::units::SystemdUnitStats;
-
 #[derive(Error, Debug)]
 pub enum MonitordTimerError {
     #[error("Timer D-Bus error: {0}")]
@@ -48,9 +46,9 @@ pub struct TimerStats {
 
 pub const TIMER_STATS_FIELD_NAMES: &[&str] = &TimerStats::FIELD_NAMES_AS_ARRAY;
 
+#[tracing::instrument(level = "debug", skip(connection))]
 pub async fn collect_timer_stats(
     connection: &zbus::Connection,
-    stats: &mut SystemdUnitStats,
     unit: &crate::units::ListedUnit,
 ) -> Result<TimerStats, MonitordTimerError> {
     let mut timer_stats = TimerStats::default();
@@ -127,14 +125,6 @@ pub async fn collect_timer_stats(
     timer_stats.randomized_delay_usec = randomized_delay_usec?;
     timer_stats.remain_after_elapse = remain_after_elapse?;
 
-    if timer_stats.persistent {
-        stats.timer_persistent_units += 1;
-    }
-
-    if timer_stats.remain_after_elapse {
-        stats.timer_remain_after_elapse += 1;
-    }
-
     Ok(timer_stats)
 }
 
@@ -175,8 +165,14 @@ pub async fn collect_all_timers_dbus(
         if !config.timers.allowlist.is_empty() && !config.timers.allowlist.contains(&unit.name) {
             continue;
         }
-        match collect_timer_stats(connection, &mut stats, &unit).await {
+        match collect_timer_stats(connection, &unit).await {
             Ok(ts) => {
+                if ts.persistent {
+                    stats.timer_persistent_units += 1;
+                }
+                if ts.remain_after_elapse {
+                    stats.timer_remain_after_elapse += 1;
+                }
                 timer_stats_map.insert(unit.name.clone(), ts);
             }
             Err(err) => {

--- a/src/units.rs
+++ b/src/units.rs
@@ -13,9 +13,12 @@ use std::time::UNIX_EPOCH;
 use struct_field_names_as_array::FieldNamesAsArray;
 use thiserror::Error;
 use tokio::sync::RwLock;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
 use tracing::debug;
 use tracing::error;
 use tracing::warn;
+use tracing::Instrument;
 use zbus::zvariant::ObjectPath;
 use zbus::zvariant::OwnedObjectPath;
 
@@ -58,6 +61,9 @@ pub struct UnitsCollectionTimings {
     pub state_dbus_fetches: u64,
     /// Number of per-service D-Bus property fetches this run.
     pub service_dbus_fetches: u64,
+    /// Slowest units (by per-unit collection duration, descending) this run,
+    /// truncated to `units.slowest_units_count`. Empty when disabled (count 0).
+    pub slowest_units: Vec<(String, f64)>,
 }
 
 /// Unit file counts for a scope (root or user), broken down by unit type.
@@ -262,6 +268,7 @@ pub const UNIT_FIELD_NAMES: &[&str] = &SystemdUnitStats::FIELD_NAMES_AS_ARRAY;
 pub const UNIT_STATES_FIELD_NAMES: &[&str] = &UnitStates::FIELD_NAMES_AS_ARRAY;
 
 /// Pull out selected systemd service statistics
+#[tracing::instrument(level = "debug", skip(connection, object_path))]
 async fn parse_service(
     connection: &zbus::Connection,
     name: &str,
@@ -338,6 +345,7 @@ async fn parse_service(
     })
 }
 
+#[tracing::instrument(level = "debug", skip(connection))]
 async fn get_time_in_state(
     connection: Option<&zbus::Connection>,
     unit: &ListedUnit,
@@ -369,25 +377,26 @@ async fn get_time_in_state(
     }
 }
 
-/// Parse state of a unit into our unit_states hash.
+/// Parse state of a unit into a `UnitStates` entry for the caller to merge.
 ///
-/// Returns true when an actual time-in-state D-Bus fetch was performed,
-/// so callers can keep `state_dbus_fetches` honest. Allowlist/blocklist
-/// short-circuits and `state_stats_time_in_state = false` both return false.
+/// Returns `(did_dbus_fetch, entry)`: `did_dbus_fetch` is true when an actual
+/// time-in-state D-Bus fetch was performed, so callers can keep
+/// `state_dbus_fetches` honest. Allowlist/blocklist short-circuits return
+/// `(false, None)` — the unit is simply not tracked in `unit_states`.
+#[tracing::instrument(level = "debug", skip(config, connection))]
 pub async fn parse_state(
-    stats: &mut SystemdUnitStats,
     unit: &ListedUnit,
     config: &crate::config::UnitsConfig,
     connection: Option<&zbus::Connection>,
-) -> Result<bool, MonitordUnitsError> {
+) -> Result<(bool, Option<UnitStates>), MonitordUnitsError> {
     if config.state_stats_blocklist.contains(&unit.name) {
         debug!("Skipping state stats for {} due to blocklist", &unit.name);
-        return Ok(false);
+        return Ok((false, None));
     }
     if !config.state_stats_allowlist.is_empty()
         && !config.state_stats_allowlist.contains(&unit.name)
     {
-        return Ok(false);
+        return Ok((false, None));
     }
     let active_state = SystemdUnitActiveState::from_str(&unit.active_state)
         .unwrap_or(SystemdUnitActiveState::unknown);
@@ -420,23 +429,21 @@ pub async fn parse_state(
         did_dbus_fetch = connection.is_some();
     }
 
-    stats.unit_states.insert(
-        unit.name.clone(),
-        UnitStates {
+    let entry = UnitStates {
+        active_state,
+        load_state,
+        unhealthy: is_unit_unhealthy_for_service(
             active_state,
             load_state,
-            unhealthy: is_unit_unhealthy_for_service(
-                active_state,
-                load_state,
-                is_oneshot_service,
-                config.ignore_inactive_oneshot_services,
-            ),
-            time_in_state_usecs,
-        },
-    );
-    Ok(did_dbus_fetch)
+            is_oneshot_service,
+            config.ignore_inactive_oneshot_services,
+        ),
+        time_in_state_usecs,
+    };
+    Ok((did_dbus_fetch, Some(entry)))
 }
 
+#[tracing::instrument(level = "debug", skip(connection))]
 async fn is_oneshot_service_unit(
     connection: &zbus::Connection,
     unit: &ListedUnit,
@@ -606,9 +613,24 @@ pub async fn collect_unit_files_stats(fs_root: &str) -> UnitFilesStats {
     }
 }
 
+/// Owned result of one unit's concurrent D-Bus work, merged into `SystemdUnitStats`
+/// by the caller once the spawned task completes. Keeping this owned (rather than
+/// mutating `SystemdUnitStats` from multiple concurrent tasks) avoids needing a
+/// `Mutex`/`RwLock` around it.
+#[derive(Default)]
+struct PerUnitOutcome {
+    unit_name: String,
+    unit_states_entry: Option<UnitStates>,
+    state_dbus_fetch: bool,
+    service_stats_entry: Option<ServiceStats>,
+    timer_stats_entry: Option<TimerStats>,
+    duration_ms: f64,
+}
+
 /// Pull all units from dbus and count how system is setup and behaving
+#[tracing::instrument(level = "debug", skip(config, connection))]
 pub async fn parse_unit_state(
-    config: &crate::config::Config,
+    config: &Arc<crate::config::Config>,
     connection: &zbus::Connection,
     fs_root: &str,
 ) -> Result<SystemdUnitStats, MonitordUnitsError> {
@@ -664,62 +686,133 @@ pub async fn parse_unit_state(
     let mut service_dbus_fetches: u64 = 0;
     let mut timer_dbus_fetches: u64 = 0;
 
-    for unit_raw in units {
-        let unit: ListedUnit = unit_raw.into();
-        // Collect unit types + states counts
-        parse_unit(&mut stats, &unit);
+    // Cheap synchronous unit-type/state counting first, separate from the
+    // concurrent D-Bus work below — no .await, so no reason to involve the
+    // per-unit tasks in it.
+    let listed_units: Vec<ListedUnit> = units.into_iter().map(ListedUnit::from).collect();
+    for unit in &listed_units {
+        parse_unit(&mut stats, unit);
+    }
 
-        // Collect per unit state stats - ActiveState + LoadState
-        // Not collecting SubState (yet)
-        if config.units.state_stats {
-            let did_dbus_fetch =
-                parse_state(&mut stats, &unit, &config.units, Some(connection)).await?;
-            if did_dbus_fetch {
-                state_dbus_fetches += 1;
-            }
-        }
-
-        // Collect service stats
-        if config.services.contains(&unit.name) {
-            debug!("Collecting service stats for {:?}", &unit);
-            match parse_service(connection, &unit.name, &unit.unit_object_path).await {
-                Ok(service_stats) => {
-                    stats.service_stats.insert(unit.name.clone(), service_stats);
-                    service_dbus_fetches += 1;
-                }
-                Err(err) => error!(
-                    "Unable to get service stats for {} {}: {:#?}",
-                    &unit.name, &unit.unit_object_path, err
-                ),
-            }
-        }
-
-        // Collect timer stats
-        if config.timers.enabled && unit.name.contains(".timer") {
-            if config.timers.blocklist.contains(&unit.name) {
-                debug!("Skipping timer stats for {} due to blocklist", &unit.name);
-                continue;
-            }
-            if !config.timers.allowlist.is_empty() && !config.timers.allowlist.contains(&unit.name)
-            {
-                continue;
-            }
-            let timer_stats: Option<TimerStats> =
-                match crate::timer::collect_timer_stats(connection, &mut stats, &unit).await {
-                    Ok(ts) => {
-                        timer_dbus_fetches += 1;
-                        Some(ts)
-                    }
-                    Err(err) => {
-                        error!("Failed to get {} stats: {:#?}", &unit.name, err);
-                        None
-                    }
+    // Bounded-concurrency D-Bus work per unit. A semaphore (rather than an
+    // unbounded join) caps how many units are in flight at once: a burst of
+    // simultaneous D-Bus calls could itself worsen host-level IPC contention
+    // on hosts where per-call latency is already elevated, which is exactly
+    // the failure mode this loop exists to avoid.
+    let semaphore = Arc::new(Semaphore::new(
+        config.units.per_unit_concurrency.max(1) as usize
+    ));
+    let mut join_set: JoinSet<PerUnitOutcome> = JoinSet::new();
+    for unit in listed_units {
+        let semaphore = Arc::clone(&semaphore);
+        let config = Arc::clone(config);
+        let connection = connection.clone();
+        join_set.spawn(async move {
+            let _permit = semaphore
+                .acquire()
+                .await
+                .expect("semaphore closed unexpectedly");
+            let unit_collect_start = Instant::now();
+            let span = tracing::debug_span!("unit_collect", unit = %unit.name);
+            let mut outcome = async {
+                let mut outcome = PerUnitOutcome {
+                    unit_name: unit.name.clone(),
+                    ..Default::default()
                 };
-            if let Some(ts) = timer_stats {
-                stats.timer_stats.insert(unit.name.clone(), ts);
+
+                // Collect per unit state stats - ActiveState + LoadState.
+                // Not collecting SubState (yet). A D-Bus error on one unit
+                // is logged and skipped rather than aborting the whole
+                // collection cycle for every other unit.
+                if config.units.state_stats {
+                    match parse_state(&unit, &config.units, Some(&connection)).await {
+                        Ok((did_fetch, entry)) => {
+                            outcome.state_dbus_fetch = did_fetch;
+                            outcome.unit_states_entry = entry;
+                        }
+                        Err(err) => {
+                            error!("Unable to get state for {}: {:?}", unit.name, err);
+                        }
+                    }
+                }
+
+                // Collect service stats
+                if config.services.contains(&unit.name) {
+                    debug!("Collecting service stats for {:?}", &unit);
+                    match parse_service(&connection, &unit.name, &unit.unit_object_path).await {
+                        Ok(service_stats) => outcome.service_stats_entry = Some(service_stats),
+                        Err(err) => error!(
+                            "Unable to get service stats for {} {}: {:#?}",
+                            &unit.name, &unit.unit_object_path, err
+                        ),
+                    }
+                }
+
+                // Collect timer stats
+                if config.timers.enabled
+                    && unit.name.contains(".timer")
+                    && !config.timers.blocklist.contains(&unit.name)
+                    && (config.timers.allowlist.is_empty()
+                        || config.timers.allowlist.contains(&unit.name))
+                {
+                    match crate::timer::collect_timer_stats(&connection, &unit).await {
+                        Ok(ts) => outcome.timer_stats_entry = Some(ts),
+                        Err(err) => error!("Failed to get {} stats: {:#?}", &unit.name, err),
+                    }
+                }
+
+                outcome
             }
+            .instrument(span)
+            .await;
+
+            outcome.duration_ms = unit_collect_start.elapsed().as_secs_f64() * 1000.0;
+            outcome
+        });
+    }
+
+    let mut slowest_units: Vec<(String, f64)> = Vec::new();
+    while let Some(res) = join_set.join_next().await {
+        let outcome = match res {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                error!("Per-unit collection task failed to join: {:?}", err);
+                continue;
+            }
+        };
+        if let Some(entry) = outcome.unit_states_entry {
+            stats.unit_states.insert(outcome.unit_name.clone(), entry);
+        }
+        if outcome.state_dbus_fetch {
+            state_dbus_fetches += 1;
+        }
+        if let Some(service_stats) = outcome.service_stats_entry {
+            stats
+                .service_stats
+                .insert(outcome.unit_name.clone(), service_stats);
+            service_dbus_fetches += 1;
+        }
+        if let Some(ts) = outcome.timer_stats_entry {
+            if ts.persistent {
+                stats.timer_persistent_units += 1;
+            }
+            if ts.remain_after_elapse {
+                stats.timer_remain_after_elapse += 1;
+            }
+            stats.timer_stats.insert(outcome.unit_name.clone(), ts);
+            timer_dbus_fetches += 1;
+        }
+        if config.units.slowest_units_count > 0 {
+            slowest_units.push((outcome.unit_name, outcome.duration_ms));
         }
     }
+
+    if config.units.slowest_units_count > 0 {
+        slowest_units.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        slowest_units.truncate(config.units.slowest_units_count as usize);
+        stats.collection_timings.slowest_units = slowest_units;
+    }
+
     let per_unit_loop_elapsed = per_unit_loop_start.elapsed();
     stats.collection_timings.per_unit_loop_ms = per_unit_loop_elapsed.as_secs_f64() * 1000.0;
     stats.collection_timings.state_dbus_fetches = state_dbus_fetches;
@@ -819,7 +912,10 @@ mod tests {
 
         // Test no allow list or blocklist; with connection: None, parse_state
         // takes the no-op path inside get_time_in_state and returns false.
-        let did_fetch = parse_state(&mut stats, &systemd_unit, &config, None).await?;
+        let (did_fetch, entry) = parse_state(&systemd_unit, &config, None).await?;
+        if let Some(entry) = entry {
+            stats.unit_states.insert(systemd_unit.name.clone(), entry);
+        }
         assert_eq!(expected_stats, stats);
         assert!(!did_fetch);
 
@@ -828,7 +924,12 @@ mod tests {
 
         // test no blocklist and only allow list - Should equal the same as no lists above
         let mut allowlist_stats = SystemdUnitStats::default();
-        let did_fetch = parse_state(&mut allowlist_stats, &systemd_unit, &config, None).await?;
+        let (did_fetch, entry) = parse_state(&systemd_unit, &config, None).await?;
+        if let Some(entry) = entry {
+            allowlist_stats
+                .unit_states
+                .insert(systemd_unit.name.clone(), entry);
+        }
         assert_eq!(expected_stats, allowlist_stats);
         assert!(!did_fetch);
 
@@ -838,7 +939,12 @@ mod tests {
         // test blocklist with allow list (show it's preferred)
         let mut blocklist_stats = SystemdUnitStats::default();
         let expected_blocklist_stats = SystemdUnitStats::default();
-        let did_fetch = parse_state(&mut blocklist_stats, &systemd_unit, &config, None).await?;
+        let (did_fetch, entry) = parse_state(&systemd_unit, &config, None).await?;
+        if let Some(entry) = entry {
+            blocklist_stats
+                .unit_states
+                .insert(systemd_unit.name.clone(), entry);
+        }
         assert_eq!(expected_blocklist_stats, blocklist_stats);
         // Blocklist short-circuit must NOT count as a D-Bus fetch.
         assert!(!did_fetch);

--- a/src/varlink_units.rs
+++ b/src/varlink_units.rs
@@ -382,6 +382,7 @@ mod tests {
             state_stats_time_in_state: false,
             ignore_inactive_oneshot_services: true,
             unit_files: true,
+            ..Default::default()
         }
     }
 
@@ -637,6 +638,7 @@ mod tests {
             state_stats_time_in_state: true,
             ignore_inactive_oneshot_services: true,
             unit_files: true,
+            ..Default::default()
         };
         let mut stats = SystemdUnitStats::default();
 
@@ -936,6 +938,7 @@ mod tests {
             state_stats_time_in_state: false,
             ignore_inactive_oneshot_services: true,
             unit_files: true,
+            ..Default::default()
         };
 
         // Allowed unit should be tracked
@@ -970,6 +973,7 @@ mod tests {
             state_stats_time_in_state: false,
             ignore_inactive_oneshot_services: true,
             unit_files: true,
+            ..Default::default()
         };
 
         // Blocked unit should be skipped
@@ -1004,6 +1008,7 @@ mod tests {
             state_stats_time_in_state: false,
             ignore_inactive_oneshot_services: true,
             unit_files: true,
+            ..Default::default()
         };
 
         // Unit in both lists should be blocked (blocklist takes priority)
@@ -1030,6 +1035,7 @@ mod tests {
             state_stats_time_in_state: false,
             ignore_inactive_oneshot_services: true,
             unit_files: true,
+            ..Default::default()
         };
         let mut stats = SystemdUnitStats::default();
 
@@ -1085,6 +1091,7 @@ mod tests {
             state_stats_time_in_state: false,
             ignore_inactive_oneshot_services: true,
             unit_files: true,
+            ..Default::default()
         };
         let mut stats = SystemdUnitStats::default();
 


### PR DESCRIPTION
## Summary

`us.cooperlees.com`'s `per_unit_loop_ms` averaged 803ms over 6h (spikes to 2.5s) vs 128-272ms on other VPS/router hosts, despite having *fewer* total units than home1/home2 — pointing at host-level D-Bus/IPC contention on that box, not unit count. Root cause: `parse_unit_state`'s per-unit loop issued up to 3 D-Bus round trips per unit strictly sequentially, one at a time, so any per-call latency there gets paid N times in series.

- Replaces the sequential loop with a `Semaphore`-gated `JoinSet` (new `units.per_unit_concurrency` config, default 8) — matches the concurrency pattern `lib.rs` already uses for its top-level collectors. Each spawned task returns an owned result merged into `stats` single-threaded as tasks complete, no `Mutex`/`RwLock` needed.
- `parse_state`'s per-unit D-Bus error now logs and continues instead of aborting the whole units collector for every other unit (matches `parse_service`'s existing pattern; effectively forced by the concurrent design).
- New `units.slowest_units_count` diagnostic (default 5): records the slowest units by per-unit collection duration, surfaced in both `json-pretty` and `json-flat` output.
- `#[tracing::instrument]` spans on the units/timer D-Bus collection functions, plus a per-unit `debug_span` — inert without a subscriber, paves the way for OTLP export in `monitord-exporter`.
- Varlink path untouched except a mechanical 2-line addition at `collect_all_timers_dbus`'s call site (moving bookkeeping that used to live inside `collect_timer_stats` out to the caller, both callers).

## Real-world validation

Built and ran directly on `us.cooperlees.com` (release build, 5 runs each, isolated `[units]`-only config matching production's actual `state_stats` settings):

| | avg `per_unit_loop_ms` |
|---|---|
| baseline (sequential, pre-fix) | ~515ms |
| `per_unit_concurrency=4` | ~203ms |
| `per_unit_concurrency=8` | ~118ms |
| `per_unit_concurrency=16` | ~113ms |
| `per_unit_concurrency=32` | ~98ms |

~4.4x improvement at the chosen default of 8, with diminishing returns above it and no sign that higher concurrency itself worsens contention. `state_dbus_fetches` and `unit_states` entry count stayed at 507/507 in every run — no data loss from the log-and-continue error handling change.

## Test plan

- [x] `cargo test` (117 tests, including new config-override tests and an updated golden JSON flatten test)
- [x] `cargo clippy --all-targets` (no new warnings)
- [x] `cargo fmt --check`
- [x] `cargo build --release --all-features`
- [x] Manual before/after validation directly on `us.cooperlees.com` (see above)