### PR TITLE
Fix update_version/update_system_stats holding the stats lock across their D-Bus call

### DIFF
--- a/src/pid1.rs
+++ b/src/pid1.rs
@@ -11,6 +11,7 @@ use procfs::process::Process;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::error;
+use tracing::Instrument;
 
 use crate::MachineStats;
 
@@ -72,16 +73,26 @@ pub fn get_pid_stats(_pid: i32) -> Result<Pid1Stats, MonitordPid1Error> {
 }
 
 /// Async wrapper than can update PID1 stats when passed a locked struct
+///
+/// Split into two spans (blocking procfs read vs. write-lock acquisition) so a
+/// slow run can be attributed to actual work vs. contention on the
+/// `MachineStats` lock shared with every other collector.
 pub async fn update_pid1_stats(
     pid: i32,
     locked_machine_stats: Arc<RwLock<MachineStats>>,
 ) -> anyhow::Result<()> {
-    let pid1_stats = match tokio::task::spawn_blocking(move || get_pid_stats(pid)).await {
+    let pid1_stats = match tokio::task::spawn_blocking(move || get_pid_stats(pid))
+        .instrument(tracing::debug_span!("pid1_blocking_read"))
+        .await
+    {
         Ok(p1s) => p1s,
         Err(err) => return Err(err.into()),
     };
 
-    let mut machine_stats = locked_machine_stats.write().await;
+    let mut machine_stats = locked_machine_stats
+        .write()
+        .instrument(tracing::debug_span!("pid1_acquire_write_lock"))
+        .await;
     machine_stats.pid1 = match pid1_stats {
         Ok(s) => Some(s),
         Err(err) => {

--- a/src/system.rs
+++ b/src/system.rs
@@ -15,6 +15,7 @@ use strum_macros::EnumString;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::error;
+use tracing::Instrument;
 
 use crate::MachineStats;
 
@@ -174,14 +175,24 @@ pub async fn get_system_state(
 }
 
 /// Async wrapper than can update system stats when passed a locked struct
+///
+/// The D-Bus call runs before the write lock is taken (not while holding it):
+/// `locked_machine_stats` is shared by every collector, so holding it across an
+/// awaited D-Bus round trip would block every other collector's own (already
+/// finished) write until this one's D-Bus call completes.
 pub async fn update_system_stats(
     connection: zbus::Connection,
     locked_machine_stats: Arc<RwLock<MachineStats>>,
 ) -> anyhow::Result<()> {
-    let mut machine_stats = locked_machine_stats.write().await;
-    machine_stats.system_state = crate::system::get_system_state(&connection)
+    let system_state = crate::system::get_system_state(&connection)
+        .instrument(tracing::debug_span!("system_state_dbus_call"))
         .await
         .map_err(|e| anyhow::anyhow!("Error getting system state: {:?}", e))?;
+    let mut machine_stats = locked_machine_stats
+        .write()
+        .instrument(tracing::debug_span!("system_state_acquire_write_lock"))
+        .await;
+    machine_stats.system_state = system_state;
     Ok(())
 }
 
@@ -198,14 +209,22 @@ pub async fn get_version(
 }
 
 /// Async wrapper than can update system stats when passed a locked struct
+///
+/// See `update_system_stats` above: the D-Bus call runs before the write lock
+/// is taken so it doesn't hold the shared lock for the round trip's duration.
 pub async fn update_version(
     connection: zbus::Connection,
     locked_machine_stats: Arc<RwLock<MachineStats>>,
 ) -> anyhow::Result<()> {
-    let mut machine_stats = locked_machine_stats.write().await;
-    machine_stats.version = crate::system::get_version(&connection)
+    let version = crate::system::get_version(&connection)
+        .instrument(tracing::debug_span!("version_dbus_call"))
         .await
         .map_err(|e| anyhow::anyhow!("Error getting systemd version: {:?}", e))?;
+    let mut machine_stats = locked_machine_stats
+        .write()
+        .instrument(tracing::debug_span!("version_acquire_write_lock"))
+        .await;
+    machine_stats.version = version;
     Ok(())
 }
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -833,14 +833,21 @@ pub async fn parse_unit_state(
 /// Async wrapper that can update unit stats when passed a locked struct.
 /// `fs_root` is prepended to filesystem paths for unit file stats —
 /// empty string for the host, `/proc/<pid>/root` for containers.
+///
+/// The whole (potentially hundreds-of-D-Bus-calls) collection runs before the
+/// write lock is taken, not while holding it: `locked_machine_stats` is
+/// shared by every collector, so holding it across the entire per-unit loop
+/// would block every other collector's own (often much quicker) write until
+/// this collection finished.
 pub async fn update_unit_stats(
     config: Arc<crate::config::Config>,
     connection: zbus::Connection,
     locked_machine_stats: Arc<RwLock<MachineStats>>,
     fs_root: String,
 ) -> anyhow::Result<()> {
+    let units_stats = parse_unit_state(&config, &connection, &fs_root).await;
     let mut machine_stats = locked_machine_stats.write().await;
-    match parse_unit_state(&config, &connection, &fs_root).await {
+    match units_stats {
         Ok(units_stats) => machine_stats.units = units_stats,
         Err(err) => error!("units stats failed: {:?}", err),
     }


### PR DESCRIPTION
## Summary

Two instances of the same bug: a collector acquiring the shared `locked_machine_stats` write lock **before** doing its real work, and holding it for that work's entire duration, instead of doing the work first and only taking the lock briefly to store the result (the pattern every other collector already uses correctly — pid1, networkd, verify, boot_blame, dbus_stats).

- `update_version` / `update_system_stats` (`src/system.rs`): held the lock across their own D-Bus call. `version` is always spawned first, so this could hold the lock hostage for its own D-Bus latency.
- `units::update_unit_stats` (`src/units.rs`, the D-Bus fallback path — the default, since varlink is off by default): held the lock across the **entire per-unit collection loop** — hundreds of D-Bus calls, ~80-140ms of real work. This turned out to be the dominant contributor. `varlink_units::update_unit_stats` already had the correct ordering, so only the D-Bus path was affected.

Also added debug spans around the D-Bus call and lock acquisition in `pid1.rs`/`system.rs` so a future slow run can be directly attributed to real work vs. lock contention from a live trace, rather than inferred.

## Context

This follows the tracing span-propagation fix in 0.26.0 (span nesting was broken before that, so this pattern was invisible in Tempo). With connected traces now working, live data from the fleet showed `pid1`/`networkd`/`units`/`boot_blame`/`verify`/`dbus_stats` all fully overlapping in time but converging to the same completion time regardless of individual workload — including `pid1`, which does no D-Bus calls at all. That pointed at contention on something shared rather than D-Bus itself, and a source read turned up these two lock-ordering bugs.

## Verification

- `cargo build --all-features`, `cargo test --lib` (114 passed), `cargo clippy --all-features`, `cargo fmt --check` all clean.
- Verified empirically against live Tempo, not just by inspection: built `monitord-exporter` against this branch via a local path override, ran back-to-back scrapes against the same host at each stage. The previously-converged collector cluster went ~147ms (before) → ~99ms (system.rs fix only) → ~47ms (both fixes) for the same host.
- A smaller residual convergence remains at ~47ms — `pid1` (no D-Bus calls at all) still converges with the others, which rules out a further lock-ordering bug and points at Tokio worker-thread contention from the per-unit loop's concurrent D-Bus response parsing instead. That's a separate, larger follow-up (likely concurrency tuning or leaning further into the varlink migration already scaffolded in this codebase), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DxpC6ix5whzpAfvX6okkU